### PR TITLE
Demo-slice v2 client (submit / poll / download)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package with dev dependencies
+        run: pip install -e .[dev]
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Check formatting with ruff
+        run: ruff format --check .
+
+      - name: Type check with mypy
+        run: mypy src
+
+      - name: Run tests
+        run: pytest -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+# Scaffold only — publishing is intentionally turned OFF until the PyPI side
+# is set up. Do not remove the `if: false` guard below without doing the TODO
+# items first; this file exists so the pipeline shape is reviewed now and can
+# be switched on with a small, obvious diff later.
+#
+# TODO before enabling:
+#   1. Create the `comfy-sdk` project on PyPI (or reserve the name).
+#   2. On pypi.org, add a "Trusted Publisher" for this repo pointing at:
+#        repo:        Comfy-Org/ComfyPythonSDK
+#        workflow:    publish.yml
+#        environment: pypi
+#      (Trusted Publishing lets PyPI accept an upload via OIDC — no long-lived
+#      API token needs to be stored as a GitHub secret.)
+#   3. Create a GitHub Environment named "pypi" in this repo's settings and
+#      add required reviewers, so every publish needs a manual approval click
+#      even after this workflow is triggered.
+#   4. Once 1-3 are done, remove the `if: false` line in the `publish` job
+#      below (that's the only change needed to turn this on) — the manual
+#      workflow_dispatch trigger and the environment approval gate stay as
+#      the permanent safety net; nothing publishes on every tag automatically.
+name: Publish to PyPI
+
+on:
+  # Manual only, on purpose: the org's current decision is manual publish,
+  # not "every GitHub Release auto-publishes." A maintainer runs this from
+  # the Actions tab, picking the git tag/ref to build from.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag or ref to publish (e.g. v0.1.0)'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # Disabled until the PyPI Trusted Publisher + "pypi" environment above
+    # are configured. See the TODO block at the top of this file.
+    if: false
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment: pypi # requires manual approval once the environment exists with reviewers configured
+    permissions:
+      id-token: write # required for PyPI Trusted Publishing (OIDC), no API token secret needed
+      contents: read
+    steps:
+      - name: Check out ${{ github.event.inputs.ref }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Python SDK for running ComfyUI workflows via the **Comfy API v2** — the same c
 against a self-hosted ComfyUI (through `comfy-api-proxy`), Comfy Cloud, or a
 serverless deployment, changing only the base URL and key.
 
-Design: `docs/sdk/plan.md` (two-layer SDK — generated protocol bindings + a
-hand-written idiomatic layer). This repository currently holds the first-iteration
-demo slice: submit a workflow, wait for it, download the outputs.
+Design: a two-layer SDK — generated protocol bindings plus a hand-written
+idiomatic layer. This repository currently holds the first-iteration demo slice:
+submit a workflow, wait for it, download the outputs.
 
 ```python
 from comfy_sdk import Comfy
@@ -20,4 +20,4 @@ for out in job["outputs"]:
 ```
 
 Status: early. The generated protocol layer, file upload, live progress, and the
-full idiomatic surface land per the plan.
+full idiomatic surface land in later iterations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,30 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = []
 
+[project.optional-dependencies]
+dev = ["ruff", "mypy", "pytest"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/comfy_sdk"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+disallow_untyped_defs = false
+check_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "comfy-sdk"
+version = "0.0.1"
+description = "Python SDK for running ComfyUI workflows via the Comfy API v2 (self-hosted, Comfy Cloud, serverless)."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/comfy_sdk"]

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -21,7 +21,22 @@ class JobFailed(Exception):
         super().__init__(self.error.get("message", "job failed"))
 
 
+class Unauthorized(Exception):
+    """The surface rejected the request for lack of a valid API key."""
+
+
 class Comfy:
+    """Client for a Comfy API v2 surface.
+
+    ``api_key`` is optional and surface-dependent. A self-hosted ComfyUI has no
+    authentication, so the local proxy needs no key — leave it unset. Comfy Cloud
+    and serverless deployments DO require a key; pass it here. When a key is set
+    it is sent as a bearer token; when it isn't, no authentication header is sent
+    at all (so nothing is leaked to a local proxy). If a surface rejects the
+    request for lack of a key, the client raises ``Unauthorized`` with a hint
+    rather than a bare HTTP error.
+    """
+
     def __init__(self, base_url: str, api_key: str | None = None) -> None:
         self.base = base_url.rstrip("/")
         self.api_key = api_key
@@ -34,6 +49,8 @@ class Comfy:
         if body is not None:
             data = __import__("json").dumps(body).encode()
             headers["Content-Type"] = "application/json"
+        # Only authenticate when a key is set: a local proxy fronts a ComfyUI
+        # that has no auth, so we never send credentials it doesn't want.
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
         req = urllib.request.Request(url, data=data, headers=headers, method=method)
@@ -51,8 +68,19 @@ class Comfy:
                 parsed = None
             return e.code, parsed, raw
 
+    def _check_auth(self, status: int) -> None:
+        if status in (401, 403):
+            hint = (
+                "no API key was set — Comfy Cloud and serverless deployments "
+                "require one: Comfy(base_url, api_key=...)"
+                if not self.api_key
+                else "the API key was rejected (check it is valid for this surface)"
+            )
+            raise Unauthorized(f"{status}: {hint}")
+
     def submit(self, workflow: dict[str, Any]) -> dict[str, Any]:
         status, job, _ = self._request("POST", "/api/v2/jobs", {"workflow": workflow})
+        self._check_auth(status)
         if status != 201:
             raise RuntimeError(f"submit failed ({status}): {job}")
         return job
@@ -60,6 +88,7 @@ class Comfy:
     def get_job(self, job: dict[str, Any]) -> dict[str, Any]:
         # Follow the embedded self link rather than building the path ourselves.
         status, fresh, _ = self._request("GET", job["urls"]["self"])
+        self._check_auth(status)
         if status != 200:
             raise RuntimeError(f"get_job failed ({status}): {fresh}")
         return fresh

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -2,8 +2,8 @@
 
 One tiny, hand-written client that runs a workflow against ANY Comfy API v2
 surface — the local proxy or Comfy Cloud — changing only the base URL and key.
-This is the thin start of the two-layer SDK in docs/sdk/plan.md; the generated
-protocol layer and the full idiomatic surface come later.
+This is the thin start of the two-layer SDK; the generated protocol layer and the
+full idiomatic surface come later.
 """
 from __future__ import annotations
 

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -93,7 +93,9 @@ class Comfy:
             raise RuntimeError(f"get_job failed ({status}): {fresh}")
         return fresh
 
-    def run(self, workflow: dict[str, Any], timeout: float = 120.0, poll: float = 0.5) -> dict[str, Any]:
+    def run(
+        self, workflow: dict[str, Any], timeout: float = 120.0, poll: float = 0.5
+    ) -> dict[str, Any]:
         job = self.submit(workflow)
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -5,6 +5,7 @@ surface — the local proxy or Comfy Cloud — changing only the base URL and ke
 This is the thin start of the two-layer SDK; the generated protocol layer and the
 full idiomatic surface come later.
 """
+
 from __future__ import annotations
 
 import time

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -1,0 +1,85 @@
+"""Comfy SDK (first-iteration demo slice).
+
+One tiny, hand-written client that runs a workflow against ANY Comfy API v2
+surface — the local proxy or Comfy Cloud — changing only the base URL and key.
+This is the thin start of the two-layer SDK in docs/sdk/plan.md; the generated
+protocol layer and the full idiomatic surface come later.
+"""
+from __future__ import annotations
+
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+_TERMINAL = {"succeeded", "failed", "expired", "canceled"}
+
+
+class JobFailed(Exception):
+    def __init__(self, error: dict[str, Any] | None) -> None:
+        self.error = error or {}
+        super().__init__(self.error.get("message", "job failed"))
+
+
+class Comfy:
+    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+        self.base = base_url.rstrip("/")
+        self.api_key = api_key
+
+    def _request(self, method: str, path: str, body: dict | None = None) -> tuple[int, Any, bytes]:
+        # A follow-up link may be absolute or root-relative; resolve against base.
+        url = path if path.startswith("http") else self.base + path
+        data = None
+        headers = {}
+        if body is not None:
+            data = __import__("json").dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req) as r:
+                raw = r.read()
+                ctype = r.headers.get("Content-Type", "")
+                parsed = __import__("json").loads(raw) if "application/json" in ctype else None
+                return r.status, parsed, raw
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            try:
+                parsed = __import__("json").loads(raw)
+            except Exception:
+                parsed = None
+            return e.code, parsed, raw
+
+    def submit(self, workflow: dict[str, Any]) -> dict[str, Any]:
+        status, job, _ = self._request("POST", "/api/v2/jobs", {"workflow": workflow})
+        if status != 201:
+            raise RuntimeError(f"submit failed ({status}): {job}")
+        return job
+
+    def get_job(self, job: dict[str, Any]) -> dict[str, Any]:
+        # Follow the embedded self link rather than building the path ourselves.
+        status, fresh, _ = self._request("GET", job["urls"]["self"])
+        if status != 200:
+            raise RuntimeError(f"get_job failed ({status}): {fresh}")
+        return fresh
+
+    def run(self, workflow: dict[str, Any], timeout: float = 120.0, poll: float = 0.5) -> dict[str, Any]:
+        job = self.submit(workflow)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            job = self.get_job(job)
+            if job["status"] in _TERMINAL:
+                if job["status"] != "succeeded":
+                    raise JobFailed(job.get("error"))
+                return job
+            time.sleep(poll)
+        raise TimeoutError(f"job {job['id']} did not finish in {timeout}s")
+
+    def download(self, output: dict[str, Any], dest_path: str) -> str:
+        status, _, raw = self._request("GET", output["url"])
+        if status != 200:
+            raise RuntimeError(f"download failed ({status})")
+        with open(dest_path, "wb") as f:
+            f.write(raw)
+        return dest_path

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,193 @@
+"""Tests for the comfy_sdk client against a stdlib-only stub HTTP server.
+
+These tests exercise the SDK end to end (submit -> poll -> download) without
+depending on a real Comfy API v2 server or the comfy-api-proxy, so the SDK's
+own test suite stays independent of that project.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from comfy_sdk import Comfy, Unauthorized
+
+
+class _StubState:
+    """Tracks how many times the job has been polled, to simulate progress."""
+
+    def __init__(self) -> None:
+        self.poll_count = 0
+
+
+def _make_handler(state: _StubState) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format_: str, *args: Any) -> None:
+            # Silence the default request logging so test output stays clean.
+            pass
+
+        def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length) if length else b""
+            body = json.loads(raw) if raw else {}
+
+            if self.path == "/api/v2/jobs":
+                workflow = body.get("workflow", {})
+                if workflow.get("_ui_format"):
+                    # Simulates the proxy rejecting a workflow submitted in
+                    # UI (export) format instead of API format.
+                    self._send_json(
+                        422,
+                        {
+                            "error": {
+                                "message": (
+                                    "workflow must be submitted in API format, not UI format"
+                                )
+                            }
+                        },
+                    )
+                    return
+                if workflow.get("_requires_auth") and not self.headers.get("Authorization"):
+                    # Simulates a surface (Comfy Cloud / serverless) that
+                    # requires an API key and none was sent.
+                    self._send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                if workflow.get("_requires_auth") and self.headers.get("Authorization") == (
+                    "Bearer wrong-key"
+                ):
+                    # Simulates a surface rejecting an invalid key.
+                    self._send_json(403, {"error": {"message": "forbidden"}})
+                    return
+                self._send_json(
+                    201,
+                    {
+                        "id": "job-1",
+                        "status": "queued",
+                        "urls": {"self": "/api/v2/jobs/job-1"},
+                    },
+                )
+                return
+
+            self._send_json(404, {"error": {"message": "not found"}})
+
+        def do_GET(self) -> None:
+            if self.path == "/api/v2/jobs/job-1":
+                state.poll_count += 1
+                if state.poll_count < 2:
+                    self._send_json(
+                        200,
+                        {
+                            "id": "job-1",
+                            "status": "running",
+                            "urls": {"self": "/api/v2/jobs/job-1"},
+                        },
+                    )
+                else:
+                    self._send_json(
+                        200,
+                        {
+                            "id": "job-1",
+                            "status": "succeeded",
+                            "urls": {"self": "/api/v2/jobs/job-1"},
+                            "outputs": [
+                                {
+                                    "name": "out.png",
+                                    "url": "/api/v2/jobs/job-1/output/out.png",
+                                }
+                            ],
+                        },
+                    )
+                return
+
+            if self.path == "/api/v2/jobs/job-1/output/out.png":
+                body = b"\x89PNG-fake-bytes"
+                self.send_response(200)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            self._send_json(404, {"error": {"message": "not found"}})
+
+    return Handler
+
+
+@pytest.fixture
+def stub_server():
+    state = _StubState()
+    handler = _make_handler(state)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, state
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _base_url(server: HTTPServer) -> str:
+    host, port = server.server_address[:2]
+    return f"http://{host}:{port}"
+
+
+def test_submit_poll_download_happy_path(stub_server, tmp_path) -> None:
+    server, _ = stub_server
+    client = Comfy(_base_url(server))
+
+    job = client.run({"nodes": {}}, timeout=5.0, poll=0.05)
+
+    assert job["status"] == "succeeded"
+    assert job["outputs"][0]["name"] == "out.png"
+
+    dest = tmp_path / "out.png"
+    result_path = client.download(job["outputs"][0], str(dest))
+
+    assert result_path == str(dest)
+    assert dest.read_bytes() == b"\x89PNG-fake-bytes"
+
+
+def test_submit_rejects_ui_format_workflow(stub_server) -> None:
+    server, _ = stub_server
+    client = Comfy(_base_url(server))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.submit({"_ui_format": True})
+
+    assert "422" in str(exc_info.value)
+    assert "UI format" in str(exc_info.value)
+
+
+def test_submit_raises_unauthorized_when_no_api_key_set(stub_server) -> None:
+    server, _ = stub_server
+    client = Comfy(_base_url(server))  # no api_key
+
+    with pytest.raises(Unauthorized) as exc_info:
+        client.submit({"_requires_auth": True})
+
+    assert "401" in str(exc_info.value)
+    assert "no API key was set" in str(exc_info.value)
+
+
+def test_submit_raises_unauthorized_when_api_key_rejected(stub_server) -> None:
+    server, _ = stub_server
+    client = Comfy(_base_url(server), api_key="wrong-key")
+
+    with pytest.raises(Unauthorized) as exc_info:
+        client.submit({"_requires_auth": True})
+
+    assert "403" in str(exc_info.value)
+    assert "API key was rejected" in str(exc_info.value)


### PR DESCRIPTION
First-iteration demo slice of the Python SDK.

## What
A small hand-written client (`comfy_sdk.Comfy`) that runs a workflow against **any** Comfy API v2 surface — the local `comfy-api-proxy` or Comfy Cloud — changing only the base URL and (for cloud) the key.

- `submit()` / `get_job()` / `run()` (submit → poll to terminal → return) / `download()`
- Poll-first and authoritative (the plan's core principle); follows the embedded `urls.self` / output `url` links rather than constructing paths.

## Scope
Deliberately minimal for the Friday demo. Not yet here: file upload, the live-progress stream, idempotency, the generated protocol layer, and the full idiomatic surface (asset/workflow factories, typed events, async client).

## Verified
Runs end to end against `comfy-api-proxy` + a fake ComfyUI: submit → `succeeded` → PNG downloaded. UI-format graphs are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
