### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+tone_instructions: |
+  This is a public Python SDK (ComfyPythonSDK). CI already runs
+  `ruff check`, `ruff format --check`, and `mypy` on every PR — do not repeat
+  their findings or nitpick style/formatting. Focus on public API stability
+  (this SDK is consumed by external users, so flag breaking changes to
+  public method signatures or types), correct error handling for network
+  calls, and clear type hints on the public surface. Only comment on issues
+  introduced by this PR's changes; do not flag pre-existing problems in
+  moved, re-indented, or reformatted code.
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+
+  path_filters:
+    - "!**/__pycache__/**"
+    - "!**/*.pyc"
+    - "!**/*.egg-info/**"
+    - "!.venv/**"
+
+  path_instructions:
+    - path: "src/comfy_sdk/**"
+      instructions: |
+        Public SDK surface. Focus on:
+        - Backward compatibility of public classes/functions (this is a
+          published SDK; breaking a signature breaks every consumer)
+        - Correct error handling and clear exceptions for network/API failures
+        - Type hints kept accurate and exported where part of the public API
+    - path: "tests/**"
+      instructions: |
+        Verify tests exercise the described behavior rather than just
+        asserting current output (no change-detector tests).
+
+  tools:
+    ruff:
+      enabled: false
+    gitleaks:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    ast-grep:
+      essential_rules: true
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
Adds a top-level `.coderabbit.yaml` so this repo gets automated PR review, matching the convention already used by the org's other repos (ComfyUI, ComfyUI_frontend, cloud).

- English review comments, "assertive" profile, request-changes workflow on, poem/fortune off.
- Auto-review enabled on non-draft PRs; PRs titled `WIP` / `DO NOT MERGE` are skipped.
- CodeRabbit's built-in `ruff` tool is disabled because this repo's own CI already runs `ruff check` + `ruff format --check` + `mypy` — CodeRabbit's review instructions point it at public-API stability, error handling, and type-hint correctness instead of re-flagging style issues CI already catches.
- Path-specific guidance for `src/comfy_sdk/**` (this is a published SDK, so flag breaking changes to public signatures) and `tests/**` (avoid change-detector tests).
- Secret scanning (`gitleaks`) and GitHub-checks integration turned on.

## Test plan
- [x] Validated the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed no internal-only references (Linear/Notion/Slack/Datadog/internal URLs) in the file
- [ ] Confirm CodeRabbit picks up the config and reviews the next PR opened against this branch/repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)