### PR TITLE
fix: map entity-specific 404 codes (job/asset_not_found) to NotFound

### DIFF
--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -108,6 +108,12 @@ _BY_CODE: dict[str, type[ComfyError]] = {
     "idempotency_key_reuse": IdempotencyKeyReuse,
     "insufficient_credits": InsufficientCredits,
     "not_found": NotFound,
+    # public-api currently returns entity-specific 404 codes even though the
+    # spec documents the generic `not_found`; map them so a missing job/asset
+    # still raises the typed NotFound. (Server/spec reconciliation of the code
+    # set is a separate follow-up.)
+    "job_not_found": NotFound,
+    "asset_not_found": NotFound,
     "unauthorized": Unauthorized,
     "forbidden": Forbidden,
 }

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -1,0 +1,17 @@
+"""to_sdk_error must map the server's 404 codes to the typed NotFound."""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_low.errors import ApiError
+from comfy_sdk.exceptions import NotFound, to_sdk_error
+
+
+@pytest.mark.parametrize("code", ["not_found", "job_not_found", "asset_not_found"])
+def test_404_codes_map_to_notfound(code: str) -> None:
+    # public-api returns entity-specific 404 codes (job_not_found / asset_not_found)
+    # alongside the spec's generic not_found; all must raise the typed NotFound.
+    err = to_sdk_error(ApiError("not found", code=code, http_status=404))
+    assert isinstance(err, NotFound)
+    assert err.code == code


### PR DESCRIPTION
Testing against prod, `client.jobs.get("<missing-uuid>")` raised a **generic `ApiError`** ("Job not found") instead of the typed **`NotFound`** the SDK contract promises.

public-api returns entity-specific 404 error codes (`job_not_found`, `asset_not_found`) even though the spec documents the generic `not_found`, so those codes fell through `_BY_CODE` to the base error.

**Fix:** map `job_not_found` and `asset_not_found` → `NotFound`. A parametrized test covers all three 404 codes. (Reconciling the spec/server code set — generic vs. entity-specific — is a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)