### PR TITLE
feat: point Comfy Cloud at cloud.comfy.org and default base_url to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ deployment — only the base URL and an optional API key change.
 from comfy_sdk import Comfy
 
 client = Comfy("http://127.0.0.1:8189")                          # self-hosted, no key
-# client = Comfy("https://api.comfy.org", api_key="comfyui-...")   # Comfy Cloud
+# client = Comfy("https://cloud.comfy.org", api_key="comfyui-...")   # Comfy Cloud
 
 wf = client.workflows.from_file("workflow_api.json")
 
@@ -53,12 +53,12 @@ needs the optional `pil` extra: `pip install -e ".[pil]"`.
 | Surface | Example base URL | `api_key` |
 |---|---|---|
 | Self-hosted ComfyUI (behind the API proxy) | `http://127.0.0.1:8189` | Omit — no key is sent, even implicitly |
-| Comfy Cloud | `https://api.comfy.org` | Required |
+| Comfy Cloud | `https://cloud.comfy.org` | Required |
 | Serverless deployment | `https://<deployment>.comfy.org` | Required |
 
 ```python
 client = Comfy("http://127.0.0.1:8189")                        # self-hosted
-client = Comfy("https://api.comfy.org", api_key="comfyui-...")  # Comfy Cloud / serverless
+client = Comfy("https://cloud.comfy.org", api_key="comfyui-...")  # Comfy Cloud / serverless
 ```
 
 `AsyncComfy` takes the same two arguments. A key is only ever attached to
@@ -72,7 +72,7 @@ analytics) — this is request metadata only; no other data is collected. Pass
 attribute its own traffic:
 
 ```python
-client = Comfy("https://api.comfy.org", api_key="comfyui-...", client_info="my-app")
+client = Comfy("https://cloud.comfy.org", api_key="comfyui-...", client_info="my-app")
 ```
 
 ## Partner (API) node auth

--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ needs the optional `pil` extra: `pip install -e ".[pil]"`.
 | Surface | Example base URL | `api_key` |
 |---|---|---|
 | Self-hosted ComfyUI (behind the API proxy) | `http://127.0.0.1:8189` | Omit — no key is sent, even implicitly |
-| Comfy Cloud | `https://cloud.comfy.org` | Required |
+| Comfy Cloud | `https://cloud.comfy.org` — the default, may be omitted | Required |
 | Serverless deployment | `https://<deployment>.comfy.org` | Required |
 
 ```python
-client = Comfy("http://127.0.0.1:8189")                        # self-hosted
-client = Comfy("https://cloud.comfy.org", api_key="comfyui-...")  # Comfy Cloud / serverless
+client = Comfy(api_key="comfyui-...")                             # Comfy Cloud (default)
+client = Comfy("http://127.0.0.1:8189")                           # self-hosted
+client = Comfy("https://<deployment>.comfy.org", api_key="comfyui-...")  # serverless
 ```
 
 `AsyncComfy` takes the same two arguments. A key is only ever attached to
@@ -72,7 +73,7 @@ analytics) — this is request metadata only; no other data is collected. Pass
 attribute its own traffic:
 
 ```python
-client = Comfy("https://cloud.comfy.org", api_key="comfyui-...", client_info="my-app")
+client = Comfy(api_key="comfyui-...", client_info="my-app")
 ```
 
 ## Partner (API) node auth

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -13,7 +13,7 @@ info:
 servers:
 - url: http://127.0.0.1:8189
   description: Self-hosted (comfy-api-proxy)
-- url: https://api.comfy.org
+- url: https://cloud.comfy.org
   description: Comfy Cloud
 - url: https://{deployment}.comfy.org
   description: Serverless deployment (URL shape not final)

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -13,7 +13,7 @@ Quickstart::
     from comfy_sdk import Comfy
 
     client = Comfy("http://127.0.0.1:8189")            # self-hosted, no key
-    # client = Comfy("https://api.comfy.org", api_key="comfyui-...")
+    # client = Comfy("https://cloud.comfy.org", api_key="comfyui-...")
 
     wf = client.workflows.from_file("workflow_api.json")
     asset = client.assets.from_file("photo.png")       # lazy; uploaded on use

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -13,7 +13,7 @@ Quickstart::
     from comfy_sdk import Comfy
 
     client = Comfy("http://127.0.0.1:8189")            # self-hosted, no key
-    # client = Comfy("https://cloud.comfy.org", api_key="comfyui-...")
+    # client = Comfy(api_key="comfyui-...")             # Comfy Cloud (default)
 
     wf = client.workflows.from_file("workflow_api.json")
     asset = client.assets.from_file("photo.png")       # lazy; uploaded on use
@@ -26,7 +26,7 @@ Quickstart::
 from __future__ import annotations
 
 from .assets import Asset, AssetFactory, AsyncAsset, AsyncAssetFactory
-from .client import AsyncComfy, Comfy
+from .client import COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
 from .events import (
     Event,
     Log,
@@ -59,6 +59,7 @@ __version__ = "0.1.0"
 __all__ = [
     # clients
     "Comfy",
+    "COMFY_CLOUD_BASE_URL",
     "AsyncComfy",
     # assets / workflows / jobs / outputs
     "Asset",

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -30,6 +30,10 @@ from .workflows import Workflow, WorkflowFactory
 
 # How long to keep retrying a full queue before giving up (seconds).
 _QUEUE_RETRY_BUDGET = 60.0
+#: Base URL of the hosted Comfy Cloud deployment, used when none is given.
+#: Self-hosted ComfyUI and serverless deployments must pass their own base_url.
+COMFY_CLOUD_BASE_URL = "https://cloud.comfy.org"
+
 _DEFAULT_RETRY_AFTER = 2
 
 
@@ -48,7 +52,7 @@ class Comfy:
 
     def __init__(
         self,
-        base_url: str,
+        base_url: str = COMFY_CLOUD_BASE_URL,
         api_key: str | None = None,
         *,
         timeout: float | None = 30.0,
@@ -143,7 +147,7 @@ class AsyncComfy:
 
     def __init__(
         self,
-        base_url: str,
+        base_url: str = COMFY_CLOUD_BASE_URL,
         api_key: str | None = None,
         *,
         timeout: float | None = 30.0,

--- a/tests/test_default_base_url.py
+++ b/tests/test_default_base_url.py
@@ -1,0 +1,24 @@
+"""The hosted deployment is the default; every other target passes its own URL."""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_sdk import COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
+
+
+def test_constant_points_at_comfy_cloud() -> None:
+    assert COMFY_CLOUD_BASE_URL == "https://cloud.comfy.org"
+
+
+@pytest.mark.parametrize("cls", [Comfy, AsyncComfy])
+def test_defaults_to_comfy_cloud_when_no_url_given(cls: type) -> None:
+    client = cls(api_key="comfyui-test")
+    assert client._low._p.url("/jobs/j1") == COMFY_CLOUD_BASE_URL + "/api/v2/jobs/j1"
+
+
+@pytest.mark.parametrize("cls", [Comfy, AsyncComfy])
+def test_explicit_base_url_still_wins(cls: type) -> None:
+    """Self-hosted callers, and the positional form every existing caller uses."""
+    client = cls("http://127.0.0.1:8189", "comfyui-test")
+    assert client._low._p.url("/jobs/j1") == "http://127.0.0.1:8189/api/v2/jobs/j1"

--- a/tests/test_default_base_url.py
+++ b/tests/test_default_base_url.py
@@ -2,23 +2,32 @@
 
 from __future__ import annotations
 
-import pytest
-
 from comfy_sdk import COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
+
+CLOUD_JOB_URL = COMFY_CLOUD_BASE_URL + "/api/v2/jobs/j1"
+LOCAL = "http://127.0.0.1:8189"
 
 
 def test_constant_points_at_comfy_cloud() -> None:
     assert COMFY_CLOUD_BASE_URL == "https://cloud.comfy.org"
 
 
-@pytest.mark.parametrize("cls", [Comfy, AsyncComfy])
-def test_defaults_to_comfy_cloud_when_no_url_given(cls: type) -> None:
-    client = cls(api_key="comfyui-test")
-    assert client._low._p.url("/jobs/j1") == COMFY_CLOUD_BASE_URL + "/api/v2/jobs/j1"
+def test_defaults_to_comfy_cloud_when_no_url_given() -> None:
+    with Comfy(api_key="comfyui-test") as client:
+        assert client._low._p.url("/jobs/j1") == CLOUD_JOB_URL
 
 
-@pytest.mark.parametrize("cls", [Comfy, AsyncComfy])
-def test_explicit_base_url_still_wins(cls: type) -> None:
+def test_explicit_base_url_still_wins() -> None:
     """Self-hosted callers, and the positional form every existing caller uses."""
-    client = cls("http://127.0.0.1:8189", "comfyui-test")
-    assert client._low._p.url("/jobs/j1") == "http://127.0.0.1:8189/api/v2/jobs/j1"
+    with Comfy(LOCAL, "comfyui-test") as client:
+        assert client._low._p.url("/jobs/j1") == LOCAL + "/api/v2/jobs/j1"
+
+
+async def test_async_defaults_to_comfy_cloud_when_no_url_given() -> None:
+    async with AsyncComfy(api_key="comfyui-test") as client:
+        assert client._low._p.url("/jobs/j1") == CLOUD_JOB_URL
+
+
+async def test_async_explicit_base_url_still_wins() -> None:
+    async with AsyncComfy(LOCAL, "comfyui-test") as client:
+        assert client._low._p.url("/jobs/j1") == LOCAL + "/api/v2/jobs/j1"

--- a/tests/test_follow_up_links.py
+++ b/tests/test_follow_up_links.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from comfy_low.transport import _Prepared
 
 GATEWAY_BASE = "https://stagingplatformapi.comfy.org/deployment/dep_123"
-CLOUD_BASE = "https://api.comfy.org"
+CLOUD_BASE = "https://cloud.comfy.org"
 
 
 def test_gateway_self_link_resolves_against_origin() -> None:

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -38,4 +38,4 @@ def test_client_info_rejects_crlf() -> None:
     # A CR/LF in the caller token must never reach the header (no injection).
     for bad in ("evil\r\nX-Injected: 1", "line\nbreak", "carriage\rreturn"):
         with pytest.raises(ValueError):
-            Comfy("https://api.comfy.org", client_info=bad)
+            Comfy("https://cloud.comfy.org", client_info=bad)


### PR DESCRIPTION
Comfy Cloud serves `/api/v2` on `cloud.comfy.org`. `api.comfy.org` keeps serving the node registry, so this is a new hostname for the cloud API rather than a domain rename.

## Two changes

**1. Point at the new host** — `spec/openapi.yaml` `servers:`, README, the module docstring, and test fixtures.

**2. Default `base_url` to it.** It was a required argument, so every caller hardcoded a host — which is why a server-side move otherwise forces every caller to edit their own code. Now:

```python
Comfy(api_key="comfyui-...")                      # Comfy Cloud
Comfy("http://127.0.0.1:8189", "comfyui-...")     # self-hosted, unchanged
```

Applies to both `Comfy` and `AsyncComfy`. `COMFY_CLOUD_BASE_URL` is exported for callers who want the value.

Backward compatible — the positional form every existing caller uses is untouched, and an explicit `base_url` still wins.

## Verification

`pytest` — 102 passing, 3 skipped (5 new, covering both clients and both forms, asserting resolved request URLs rather than private attributes). `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)