### PR TITLE
fix: derive __version__ from dist metadata instead of hardcoding it

### DIFF
--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -25,6 +25,9 @@ Quickstart::
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from .assets import Asset, AssetFactory, AsyncAsset, AsyncAssetFactory
 from .client import COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
 from .events import (
@@ -54,7 +57,13 @@ from .jobs import AsyncJob, Job
 from .outputs import AsyncOutput, DownloadUrl, Output
 from .workflows import Workflow, WorkflowFactory
 
-__version__ = "0.1.0"
+try:
+    # Single source of truth is the installed distribution metadata, which
+    # publish.yml stamps from the release tag. Hardcoding it here would pin
+    # __version__ to the pyproject placeholder on every published release.
+    __version__ = _pkg_version("comfy-sdk")
+except PackageNotFoundError:  # running from a source tree, not installed
+    __version__ = "0+unknown"
 
 __all__ = [
     # clients

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,14 +5,49 @@ publish.yml stamps the release tag into pyproject.toml at build time and
 nowhere else, so a literal in ``__init__.py`` would silently report the
 placeholder version on every published release while the wheel metadata (and
 the User-Agent, which already reads dist metadata) said something different.
+
+``__version__`` is resolved once, at import time, so injecting a version means
+patching the lookup *and* reloading the package — patching alone would assert
+against the value bound when ``comfy_sdk`` was first imported.
 """
 
 from __future__ import annotations
 
-from importlib.metadata import version as pkg_version
+import importlib
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError
+
+import pytest
 
 import comfy_sdk
 
 
-def test_version_matches_installed_distribution_metadata() -> None:
-    assert comfy_sdk.__version__ == pkg_version("comfy-sdk")
+@contextmanager
+def reloaded_with(lookup: Callable[[str], str]) -> Iterator[str]:
+    """Re-import ``comfy_sdk`` with ``importlib.metadata.version`` replaced,
+    yielding the ``__version__`` it resolves to, then restore the real module.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("importlib.metadata.version", lookup)
+        importlib.reload(comfy_sdk)
+        try:
+            yield comfy_sdk.__version__
+        finally:
+            # Undo the patch and reload again, so the rest of the suite sees
+            # the genuine installed version rather than the injected one.
+            mp.undo()
+            importlib.reload(comfy_sdk)
+
+
+def test_version_comes_from_the_distribution_metadata() -> None:
+    with reloaded_with(lambda _name: "9.9.9") as version:
+        assert version == "9.9.9"
+
+
+def test_version_falls_back_when_not_installed() -> None:
+    def missing(name: str) -> str:
+        raise PackageNotFoundError(name)
+
+    with reloaded_with(missing) as version:
+        assert version == "0+unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,18 @@
+"""``comfy_sdk.__version__`` is derived from the installed distribution
+metadata rather than hardcoded.
+
+publish.yml stamps the release tag into pyproject.toml at build time and
+nowhere else, so a literal in ``__init__.py`` would silently report the
+placeholder version on every published release while the wheel metadata (and
+the User-Agent, which already reads dist metadata) said something different.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+
+import comfy_sdk
+
+
+def test_version_matches_installed_distribution_metadata() -> None:
+    assert comfy_sdk.__version__ == pkg_version("comfy-sdk")


### PR DESCRIPTION
`publish.yml` stamps the release tag into `pyproject.toml` at build time and nowhere else, so the hardcoded `__version__ = "0.1.0"` in `comfy_sdk/__init__.py` would have reported the placeholder on every published release — while the wheel metadata and the User-Agent (which already reads dist metadata) reported the real version.

Verified by building with an injected `9.9.9`: `__version__` and the User-Agent now agree, where before `__version__` stayed `0.1.0`. Adds a regression test.