### PR TITLE
chore: fill in the empty package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,34 @@ version = "0.1.0"
 description = "Python SDK for running ComfyUI workflows via the Comfy API v2 (self-hosted, Comfy Cloud, serverless)."
 readme = "README.md"
 requires-python = ">=3.10"
+authors = [{ name = "Comfy Org" }]
+keywords = ["comfyui", "comfy", "sdk", "generative-ai", "diffusion", "workflow"]
+# No "License :: OSI Approved" classifier here on purpose: PyPI rejects
+# uploads that set a license classifier alongside a PEP 639 License-Expression.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 dependencies = [
     "httpx>=0.27",
     "blake3>=0.4",
     "pydantic>=2.6",
 ]
+
+[project.urls]
+Homepage = "https://docs.comfy.org"
+Documentation = "https://docs.comfy.org"
+Repository = "https://github.com/Comfy-Org/ComfyPythonSDK"
+Issues = "https://github.com/Comfy-Org/ComfyPythonSDK/issues"
 
 [project.optional-dependencies]
 # Preview.to_pil() decodes in-progress preview frames to PIL images.


### PR DESCRIPTION
`Author`, `Home-page`, `Project-URL`, `Keywords` and `Classifier` were all absent from the built artifact, so `pip show comfy-sdk` gave no route back to the repo or docs, and the PyPI page would carry no filterable metadata — including no signal that 3.10–3.13 are supported, which CI already tests.

Two deliberate omissions: no `License :: OSI Approved` classifier, since PyPI rejects uploads pairing one with the PEP 639 `License-Expression` added in #24; and the `Typing :: Typed` classifier here only becomes truthful once #23 ships the `py.typed` markers, so that one should merge first.