### PR TITLE
chore: make CI catch deprecations, untyped defs, and typos in config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "mypy~=2.3.0",
     "pytest~=9.1.1",
     "pytest-asyncio~=1.4.0",
+    # A .coverage database was already being produced locally (and committed)
+    # without the tool that makes it reproducible being declared anywhere.
+    "pytest-cov~=7.0",
     "datamodel-code-generator~=0.68.1",
     "Pillow>=10",
     "PyYAML>=6",
@@ -56,6 +59,33 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 exclude = ['src/comfy_low/models/_generated\.py']
 
+# comfy_sdk is the hand-written public surface and ships py.typed, so every
+# def in it should be annotated. Left off globally because comfy_low wraps
+# generated code where the guarantee isn't ours to make.
+[[tool.mypy.overrides]]
+module = "comfy_sdk.*"
+disallow_untyped_defs = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+addopts = ["--strict-markers", "--strict-config"]
+# Deprecations from httpx/pydantic/pytest-asyncio are the ones worth failing
+# on: they are the advance warning before a dependency bump breaks the SDK.
+# Deliberately not a blanket "error" -- the tests' own local HTTP servers emit
+# ResourceWarning on teardown, which would turn 63 passing tests red without
+# saying anything about the SDK.
+filterwarnings = [
+    "error::DeprecationWarning",
+    "error::PendingDeprecationWarning",
+]
+
+[tool.coverage.run]
+source = ["src/comfy_sdk", "src/comfy_low"]
+branch = true
+
+[tool.coverage.report]
+# The generated models are datamodel-code-generator output, not hand-written
+# code under test, and TYPE_CHECKING blocks never execute at runtime.
+omit = ["src/comfy_low/models/_generated.py"]
+exclude_also = ["if TYPE_CHECKING:", "raise NotImplementedError"]


### PR DESCRIPTION
Three gaps where CI currently stays green on things it should catch: dependency deprecation warnings passed silently (so a breaking httpx/pydantic bump would first show up *as* the breakage), a typo'd pytest marker or malformed ini key no-ops instead of failing, and `comfy_sdk` ships `py.typed` while unannotated defs in it were still allowed.

`filterwarnings` is scoped to Deprecation/PendingDeprecation rather than a blanket `error` on purpose — the tests' own local HTTP servers emit `ResourceWarning` on teardown, which turns 63 passing tests red without saying anything about the SDK. Also declares `pytest-cov`, which was producing a `.coverage` database locally without being declared anywhere. Verified: suite still 102 passed, mypy clean, and the new override does flag a probe untyped def.