### PR TITLE
fix: make .coderabbit.yaml valid so the repo config is actually used

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,14 +2,8 @@
 language: "en-US"
 early_access: false
 tone_instructions: |
-  This is a public Python SDK (comfy-python-sdk). CI already runs
-  `ruff check`, `ruff format --check`, and `mypy` on every PR — do not repeat
-  their findings or nitpick style/formatting. Focus on public API stability
-  (this SDK is consumed by external users, so flag breaking changes to
-  public method signatures or types), correct error handling for network
-  calls, and clear type hints on the public surface. Only comment on issues
-  introduced by this PR's changes; do not flag pre-existing problems in
-  moved, re-indented, or reformatted code.
+  Direct and technical. Lead with the concrete risk or breakage, not praise.
+  No compliments or filler — if a change is fine, say nothing.
 
 reviews:
   profile: "assertive"
@@ -35,6 +29,16 @@ reviews:
     - "!.venv/**"
 
   path_instructions:
+    # Repo-wide review rules. These used to live in `tone_instructions`, but
+    # that field is capped at 250 characters by the CodeRabbit schema, which
+    # silently invalidated this whole file.
+    - path: "**"
+      instructions: |
+        CI already runs `ruff check`, `ruff format --check`, and `mypy` on
+        every PR — do not repeat their findings or nitpick style/formatting.
+
+        Only comment on issues introduced by this PR's changes; do not flag
+        pre-existing problems in moved, re-indented, or reformatted code.
     - path: "src/comfy_sdk/**"
       instructions: |
         Public SDK surface. Focus on:


### PR DESCRIPTION
## The bug

`tone_instructions` is capped at **250 characters** by the CodeRabbit schema. This file held **539**, so the entire config failed validation — and CodeRabbit silently fell back to org-level UI settings rather than erroring. Evidence: recent reviews on this repo report

> `Configuration used: Organization UI`

So none of the reviewer guidance in this file has ever taken effect.

I verified this rather than taking the bot's word for it — fetched `https://coderabbit.ai/integrations/schema.v2.json` and validated the file with `jsonschema`:

```
tone_instructions                         maxLength:   250
reviews.path_instructions[].instructions  maxLength: 20000
```

```
before: 1 schema error  (tone_instructions: 539 > 250)
after:  0 schema errors (tone_instructions: 136)
```

That single field was the *only* error in the file.

## The fix

The schema describes `tone_instructions` as a persona field — *"Set the tone of reviews and chat. Example: 'You must talk like Mr. T.'"* — not a place for substantive review rules. So rather than deleting ~290 characters of guidance to squeeze under the cap, the repo-wide rules move to a `path: "**"` entry, which has 20000 characters of room.

**No guidance is lost:**

| Old `tone_instructions` clause | Where it lives now |
|---|---|
| Don't repeat ruff/mypy findings, don't nitpick style | new `**` path_instruction |
| Only flag issues this PR introduces, not pre-existing code | new `**` path_instruction |
| Public API stability / breaking signature changes | already in `src/comfy_sdk/**` (unchanged) |
| Correct error handling for network calls | already in `src/comfy_sdk/**` (unchanged) |
| Accurate, exported type hints | already in `src/comfy_sdk/**` (unchanged) |

The last three were already duplicated verbatim in `path_instructions`, so moving only the two genuinely cross-cutting rules keeps the diff minimal.

`tone_instructions` now carries actual tone direction, which is what the field is for.

## How to confirm it worked

The next CodeRabbit review on this repo should stop saying `Configuration used: Organization UI`. This PR is itself the first test.

The sibling fix for `comfy-typescript-sdk` is in that repo's PR.
