### PR TITLE
docs: drop comfy-swift-sdk from the v2 client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ Clients for the same Comfy API v2 contract:
 |---|---|---|
 | [comfy-python-sdk](https://github.com/Comfy-Org/comfy-python-sdk) | Python | `comfy-sdk` |
 | [comfy-typescript-sdk](https://github.com/Comfy-Org/comfy-typescript-sdk) | TypeScript | `@comfyorg/sdk` |
-| [comfy-swift-sdk](https://github.com/Comfy-Org/comfy-swift-sdk) | Swift | SwiftPM |
 
 [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy) fronts a
 self-hosted ComfyUI with this same v2 contract (it is the `comfy-api-proxy`


### PR DESCRIPTION
The `Related projects` table added during the README-consistency pass claimed the Swift SDK is a client for the same **Comfy API v2** contract. It is not.

## Evidence

`comfy-swift-sdk` declares the endpoints it depends on in [`Scripts/contract/sdk-endpoints.yml`](https://github.com/Comfy-Org/comfy-swift-sdk/blob/main/Scripts/contract/sdk-endpoints.yml), whose own header says they are *"validated against the ComfyUI front-facing OpenAPI contract (Comfy-Org/ComfyUI : openapi.yaml)"*:

| Method | Path |
|---|---|
| POST | `/api/prompt` |
| GET | `/api/queue` |
| POST | `/api/jobs/{job_id}/cancel` |
| GET | `/api/view` |
| POST | `/api/upload/image` |
| GET | `/api/jobs/{job_id}` |

None of those are `/api/v2/*`. The Python SDK, the TypeScript SDK, and `comfy-api-proxy` all speak `/api/v2/` (see their `spec/openapi.yaml` and transport layers).

So the two are different contracts that happen to both reach Comfy Cloud.

## Fix

Drops the `comfy-swift-sdk` row from the v2 client table. The table now lists only the projects that actually implement that contract.

## Provenance

My mistake — I added that row inferring the grouping from a Slack thread about repo naming rather than checking what each SDK actually calls. Caught in review by @guill on `comfy-api-proxy#15`. The same wrong claim went into `comfy-python-sdk`, `comfy-typescript-sdk`, and `comfy-swift-sdk`; this is one of three matching PRs.

Note the claim already shipped in `comfy-sdk` 0.1.5 (PyPI) and `@comfyorg/sdk` 0.1.5 (npm), since the README is the package long-description. It will correct itself on the next release of each.