### PR TITLE
feat: add embed_workflow to embed the graph in output metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,31 @@ job = client.submit(wf, api_key="comfyui-...")
 
 The SDK sends it once as `extra_data.api_key_comfy_org` alongside the workflow —
 one key authenticates every partner node in the graph. It is never logged or
-persisted by the SDK. Omit `api_key` and no `extra_data` is sent at all.
+persisted by the SDK. Omit `api_key` and leave `embed_workflow` (below) off,
+and no `extra_data` is sent at all.
+
+## Embedding the workflow in output metadata
+
+Pass `embed_workflow=True` to recover the graph later from a generated image —
+useful when debugging:
+
+```python
+job = client.run(wf, embed_workflow=True)
+# or drive it yourself:
+job = client.submit(wf, embed_workflow=True)
+```
+
+The SDK embeds the materialized graph — local files already uploaded and
+substituted with `core/ASSET` references — as `extra_data.extra_pnginfo.workflow`,
+the same key local ComfyUI's `SaveImage` writes into output PNG metadata and
+what the frontend looks for when loading a workflow from an image. Anything in
+the graph's node inputs, including values typed directly into fields, becomes
+visible to anyone who receives the image. The embedded copy keeps those
+`core/ASSET` references rather than resolved values,
+so it stays portable, but re-running it elsewhere needs access to the same
+assets. It's also still the API-format graph, so reroutes and subgraphs from
+the UI editor are not preserved — the known tradeoff, not a bug. Off by
+default; combines with `api_key` freely, since both live under `extra_data`.
 
 ## Assets and `core/ASSET`
 

--- a/src/comfy_sdk/_core.py
+++ b/src/comfy_sdk/_core.py
@@ -23,18 +23,27 @@ def new_idempotency_key() -> str:
     return str(uuid.uuid4())
 
 
-def extra_data_for(api_key: str | None) -> dict[str, Any] | None:
-    """Build the wire ``extra_data`` object carrying the partner API key.
+def extra_data_for(
+    api_key: str | None, workflow_graph: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Build the wire ``extra_data`` object.
 
     ``api_key`` authenticates partner (API) nodes (e.g. Gemini) embedded in a
     workflow — it is unrelated to the client's own ``Authorization`` bearer
-    token. Returns ``None`` when no key is supplied, so callers omit
-    ``extra_data`` from the request entirely rather than sending an empty
-    object.
+    token. ``workflow_graph``, when given, is embedded as
+    ``extra_pnginfo.workflow`` — the same key local ComfyUI's ``SaveImage``
+    writes into output PNG metadata, so the graph can be recovered from a
+    generated image. Pass the caller's own materialized graph; this function
+    does no materialization itself. Returns ``None`` when neither is supplied,
+    so callers omit ``extra_data`` from the request entirely rather than
+    sending an empty object.
     """
-    if not api_key:
-        return None
-    return {"api_key_comfy_org": api_key}
+    data: dict[str, Any] = {}
+    if api_key:
+        data["api_key_comfy_org"] = api_key
+    if workflow_graph is not None:
+        data["extra_pnginfo"] = {"workflow": workflow_graph}
+    return data or None
 
 
 def is_terminal(status: str) -> bool:

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -139,6 +139,7 @@ class Comfy:
         *,
         api_key: str | None = None,
         idempotency_key: str | None = None,
+        embed_workflow: bool = False,
     ) -> Job:
         """Submit a workflow. Retries ``queue_full`` with ``Retry-After``.
 
@@ -155,11 +156,15 @@ class Comfy:
         token this client was constructed with. It is never persisted or
         logged by the SDK, and is sent as ``extra_data.api_key_comfy_org``
         only when supplied; omitted from the request entirely otherwise.
+
+        ``embed_workflow``, when ``True``, embeds the materialized graph as
+        output metadata so it can be recovered later from a generated image —
+        useful when debugging. Off by default.
         """
         _guard_ui_format(workflow)
         graph = self._materialize(workflow)
         key = idempotency_key or _core.new_idempotency_key()
-        extra_data = _core.extra_data_for(api_key)
+        extra_data = _core.extra_data_for(api_key, graph if embed_workflow else None)
         deadline = time.monotonic() + _QUEUE_RETRY_BUDGET
         while True:
             try:
@@ -178,9 +183,10 @@ class Comfy:
         *,
         api_key: str | None = None,
         timeout: float | None = None,
+        embed_workflow: bool = False,
     ) -> Job:
         """Submit, then poll to terminal (authoritative). Raises on failure."""
-        job = self.submit(workflow, api_key=api_key)
+        job = self.submit(workflow, api_key=api_key, embed_workflow=embed_workflow)
         return job.result() if timeout is None else _run_with_timeout(job, timeout)
 
 
@@ -235,14 +241,15 @@ class AsyncComfy:
         *,
         api_key: str | None = None,
         idempotency_key: str | None = None,
+        embed_workflow: bool = False,
     ) -> AsyncJob:
-        """Mirrors :meth:`Comfy.submit` — see there for ``api_key`` details."""
+        """Mirrors :meth:`Comfy.submit` — see there for ``api_key``/``embed_workflow`` details."""
         import asyncio
 
         _guard_ui_format(workflow)
         graph = await self._materialize(workflow)
         key = idempotency_key or _core.new_idempotency_key()
-        extra_data = _core.extra_data_for(api_key)
+        extra_data = _core.extra_data_for(api_key, graph if embed_workflow else None)
         deadline = time.monotonic() + _QUEUE_RETRY_BUDGET
         while True:
             try:
@@ -261,12 +268,13 @@ class AsyncComfy:
         *,
         api_key: str | None = None,
         timeout: float | None = None,
+        embed_workflow: bool = False,
     ) -> AsyncJob:
         """Async :meth:`Comfy.run` — submit, then poll to terminal. Raises on failure."""
         from ._core import SUCCESS
         from .exceptions import JobFailed
 
-        job = await self.submit(workflow, api_key=api_key)
+        job = await self.submit(workflow, api_key=api_key, embed_workflow=embed_workflow)
         if timeout is None:
             return await job.result()
         await job.wait(timeout=timeout)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -142,6 +142,34 @@ async def test_async_submit_without_api_key_omits_extra_data(server) -> None:
     assert "extra_data" not in body
 
 
+async def test_async_submit_with_embed_workflow_embeds_materialized_graph(server) -> None:
+    # Mirrors the sync `test_submit_with_embed_workflow_embeds_materialized_graph`.
+    async with AsyncComfy() as client:
+        await client.submit(_wf(client), embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {"extra_pnginfo": {"workflow": body["workflow"]}}
+
+
+async def test_async_submit_with_embed_workflow_and_api_key_merges_extra_data(server) -> None:
+    async with AsyncComfy() as client:
+        await client.submit(_wf(client), api_key="comfyui-secret-key", embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {
+        "api_key_comfy_org": "comfyui-secret-key",
+        "extra_pnginfo": {"workflow": body["workflow"]},
+    }
+
+
+async def test_async_run_forwards_embed_workflow_to_submit(server) -> None:
+    async with AsyncComfy() as client:
+        await client.run(_wf(client), embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {"extra_pnginfo": {"workflow": body["workflow"]}}
+
+
 async def test_async_queue_full_retries_with_retry_after(server) -> None:
     server.state.queue_full_times = 2  # 429 twice, then 201
     async with AsyncComfy() as client:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -159,6 +159,63 @@ def test_submit_with_empty_string_api_key_omits_extra_data(server) -> None:
     assert "extra_data" not in body
 
 
+def test_submit_with_embed_workflow_embeds_materialized_graph(server) -> None:
+    with Comfy() as client:
+        client.submit(_wf(client), embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {"extra_pnginfo": {"workflow": body["workflow"]}}
+
+
+def test_submit_with_embed_workflow_false_omits_extra_data(server) -> None:
+    # Default is off; explicitly passing False must be byte-identical to
+    # today's wire format -- no `extra_data` key at all.
+    with Comfy() as client:
+        client.submit(_wf(client), embed_workflow=False)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert "extra_data" not in body
+
+
+def test_submit_with_embed_workflow_and_api_key_merges_extra_data(server) -> None:
+    # Both keys must coexist: the partner-node key alongside the embedded graph.
+    with Comfy() as client:
+        client.submit(_wf(client), api_key="comfyui-secret-key", embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {
+        "api_key_comfy_org": "comfyui-secret-key",
+        "extra_pnginfo": {"workflow": body["workflow"]},
+    }
+
+
+def test_submit_with_embed_workflow_embeds_materialized_not_raw_graph(server, tmp_path) -> None:
+    # The embedded graph is what actually executes (asset handles substituted
+    # for core/ASSET refs) -- not the caller's pre-materialization Workflow.json,
+    # which still holds the live handle object.
+    p = tmp_path / "photo.png"
+    p.write_bytes(b"pixels")
+    with Comfy() as client:
+        asset = client.assets.from_file(p)
+        wf = client.workflows.from_json(
+            {"10": {"class_type": "LoadImage", "inputs": {"image": asset}}}
+        )
+        client.submit(wf, embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    embedded = body["extra_data"]["extra_pnginfo"]["workflow"]
+    assert embedded == body["workflow"]
+    assert embedded["10"]["inputs"]["image"]["__type"] == "core/ASSET"
+
+
+def test_run_forwards_embed_workflow_to_submit(server) -> None:
+    with Comfy() as client:
+        client.run(_wf(client), embed_workflow=True)
+    body = server.state.last_jobs_body
+    assert body is not None
+    assert body["extra_data"] == {"extra_pnginfo": {"workflow": body["workflow"]}}
+
+
 def test_run_forwards_api_key_to_submit(server) -> None:
     # `run()` is submit-then-wait; the api_key must still reach the wire.
     with Comfy() as client:


### PR DESCRIPTION
Recovering the workflow from an image it produced isn't possible today, which makes debugging harder. Adds an opt-in flag.

```mermaid
flowchart LR
  W["workflow"] --> M["materialize<br/>(assets → core/ASSET)"]
  M --> G["graph"]
  G -- "workflow" --> R["POST /jobs"]
  G -- "extra_data.extra_pnginfo.workflow<br/>(only if embed_workflow)" --> R
  R --> P["PNG: workflow chunk"]
```

`submit()` and `run()` — sync and async — take a keyword-only `embed_workflow: bool = False`. When set, the SDK sends the materialized graph as `extra_data.extra_pnginfo.workflow`, the key local ComfyUI's `SaveImage` writes into output PNG metadata.

## Behavior

- Off by default. With no `api_key` and the flag off, the wire format is byte-identical to today: no `extra_data` at all, never `{}`. Existing tests pinning this are untouched.
- Merges with the partner-node key when both are given.
- Embeds the **materialized** graph — the same object sent as `workflow` — not the caller's input. A test asserts the `core/ASSET` substitution actually happened, so it can't pass by embedding the wrong object.

## Reviewer notes

- Needs the matching server-side contract change, landing separately — **don't merge this first**, or the flag is a no-op.
- `spec/openapi.yaml` is untouched by design (synced one-way); it picks the field up on the next sync.
- The TypeScript SDK ships the same feature as `embedWorkflow`, producing identical bytes.

`ruff`, `mypy`, `pytest` (133 passed, 4 pre-existing skips), spec-drift and hygiene checks all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)