### PR TITLE
fix: expose job_id and expires_at on the public wrappers

### DIFF
--- a/src/comfy_sdk/assets.py
+++ b/src/comfy_sdk/assets.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import mimetypes
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from io import BytesIO
 from os import PathLike
 from os.path import basename, getsize
@@ -63,6 +64,8 @@ class _AssetBase:
         self._id: str | None = None
         self._created_new: bool | None = None
         self._url: str | None = None
+        self._job_id: str | None = None
+        self._expires_at: datetime | None = None
         self._idempotency_key = _core.new_idempotency_key()
 
     @property
@@ -84,12 +87,26 @@ class _AssetBase:
     def created_new(self) -> bool | None:
         return self._created_new
 
+    @property
+    def job_id(self) -> str | None:
+        """The id of the job that produced this asset, or ``None`` for an
+        asset with no producing job (e.g. a plain upload)."""
+        return self._job_id
+
+    @property
+    def expires_at(self) -> datetime | None:
+        """Retention deadline for this asset, or ``None`` if it doesn't
+        expire."""
+        return self._expires_at
+
     def _apply(self, asset: LowAsset) -> None:
         self._id = asset.id
         if asset.hash:
             self._hash = asset.hash
         self._created_new = asset.created_new
         self._url = str(asset.url)
+        self._job_id = asset.job_id
+        self._expires_at = asset.expires_at
 
     def __repr__(self) -> str:
         state = self._id or "uncommitted"

--- a/src/comfy_sdk/outputs.py
+++ b/src/comfy_sdk/outputs.py
@@ -65,6 +65,12 @@ class Output:
     def content_type(self) -> str:
         return self._model.content_type
 
+    @property
+    def job_id(self) -> str | None:
+        """The id of the job that produced this output, or ``None`` if the
+        backend didn't report one."""
+        return self._model.job_id
+
     def to_file(self, path: str | PathLike[str], *, range: tuple[int, int] | None = None) -> Path:
         """Stream this output to ``path`` and return the path written.
 
@@ -153,6 +159,12 @@ class AsyncOutput:
     @property
     def content_type(self) -> str:
         return self._model.content_type
+
+    @property
+    def job_id(self) -> str | None:
+        """The id of the job that produced this output, or ``None`` if the
+        backend didn't report one."""
+        return self._model.job_id
 
     async def to_file(
         self, path: str | PathLike[str], *, range: tuple[int, int] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,9 @@ def _asset_json(asset_id: str, hash_: str, created_new: bool, size: int) -> dict
         "created_at": "2026-07-10T18:00:00Z",
         "url": "http://example.invalid/blob",
         "url_expires_at": "2026-07-10T19:00:00Z",
+        # Retention deadline for the asset itself — distinct from url_expires_at
+        # above. Omitted (-> None) for a plain upload with no producing job.
+        "expires_at": "2026-08-09T18:00:00Z",
     }
 
 
@@ -268,7 +271,9 @@ def _make_handler(state: ServerState):
             if state.job_poll_count >= state.polls_to_succeed:
                 status = state.terminal_status
                 if status == "succeeded":
-                    outputs = state.job_outputs if state.job_outputs is not None else [_OUTPUT]
+                    raw = state.job_outputs if state.job_outputs is not None else [_OUTPUT]
+                    # Stamp the producing job id, same as a real server would.
+                    outputs = [{**o, "job_id": job_id} for o in raw]
                 else:
                     outputs = []
             else:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from datetime import datetime, timezone
 
 import pytest
 
@@ -28,6 +29,28 @@ def test_dedup_fast_path_skips_upload(server, tmp_path) -> None:
     assert server.state.head_count == 1
     assert server.state.from_hash_count == 1
     assert server.state.upload_count == 0
+
+
+def test_uploaded_asset_has_no_producing_job(server, tmp_path) -> None:
+    # A plain upload (never a job output) must report job_id as None on the
+    # public wrapper, not just on the private generated model.
+    p = tmp_path / "photo.png"
+    p.write_bytes(b"plain-upload-bytes")
+
+    with Comfy() as client:
+        asset = client.assets.from_file(p)
+        asset.commit()
+        assert asset.job_id is None
+
+
+def test_committed_asset_exposes_expiry(server, tmp_path) -> None:
+    p = tmp_path / "photo.png"
+    p.write_bytes(b"expiring-bytes")
+
+    with Comfy() as client:
+        asset = client.assets.from_file(p)
+        asset.commit()
+        assert asset.expires_at == datetime(2026, 8, 9, 18, 0, tzinfo=timezone.utc)
 
 
 class _ReadRecorder(io.BytesIO):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -37,6 +37,15 @@ def test_run_completes_via_polling_when_sse_absent(server, tmp_path) -> None:
     assert server.state.events_connect_count == 0  # SSE never used
 
 
+def test_output_exposes_producing_job_id(server) -> None:
+    # The public Output wrapper must surface job_id, not just the private
+    # generated model — this is the field the whole feature exists to provide.
+    with Comfy() as client:
+        job = client.run(_wf(client))
+        outs = job.get_outputs("13")
+        assert outs[0].job_id == job.id
+
+
 def test_idempotent_submit_rejects_reused_key(server) -> None:
     # Keys are single-use (reject-on-duplicate, no replay): reusing the same
     # explicit key raises IdempotencyKeyReuse rather than replaying the job.


### PR DESCRIPTION
The recent spec sync added three fields to the generated models — `Output.job_id`, `Asset.job_id`, `Asset.expires_at` — but the hand-written wrapper classes never surfaced any of them. A caller couldn't reach the field the change exists to provide without touching a private attribute.

## How it was found

End-to-end testing against **Comfy Cloud staging** and a **self-hosted comfy-api-proxy**, driving a real workflow. The value was correct on the wire from both:

```
wire job_id: 94d5c5a3-db99-46e7-8dc2-90d911f8d856
SDK wrapper: <NOT EXPOSED>
```

Existing tests missed it because they assert on request and response **bodies**, never on the wrapper's surface — so the field was verified at the HTTP layer while being unreachable through the public API.

## The fix

`job_id` on `Output`/`AsyncOutput` and `Asset`/`AsyncAsset`, plus `expires_at` on the asset. `Asset` doesn't retain the full model, so those two are captured in `_apply` alongside the existing fields rather than passed through.

Typed `str | None` — genuinely absent for an uploaded asset with no producing job, so it isn't faked.

## Tests assert the wrapper, not the wire

That's the gap that let this ship. New tests: `output.job_id` equals the producing job's id after a real run; an uploaded asset's `job_id` is `None`; a committed asset's `expires_at` parses to a timezone-aware datetime. The shared fixture now stamps `job_id` onto polled outputs, which it never carried before — previously there was no way to test the real value flowing through, only its absence.

## Verified end to end, not just in unit tests

Re-ran both environments against this branch:

- **Cloud staging** — job succeeded, `output.job_id` and `asset.job_id` both match, PNG downloaded and verified, `GET /jobs/{id}/workflow` returns `format: api` with the submitted graph and no `extra_data`
- **Local ComfyUI 0.30.0 via comfy-api-proxy** — same five steps pass

`ruff`, `ruff format`, `mypy`, drift and hygiene clean; **140 tests pass**.

## Noted, not fixed

`Asset` also omits `size_bytes`, `content_type`, `created_at` and `url` from its wrapper — but those predate this sync and aren't part of the same regression, so widening the surface further belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)