### PR TITLE
docs: cover get_workflow, asset deletion, and job_id in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ a `core/ASSET` reference object (`{"__type": "core/ASSET", "info": {"id":
 ..., "hash": ..., "file_path": ...}}`), which the server resolves back to the
 uploaded asset when it runs the workflow.
 
+Once committed, an asset also carries `job_id` — the id of the job that
+produced it, or `None` for an asset with no producing job (e.g. a plain
+upload) — and `expires_at`, its retention deadline, or `None` if it doesn't
+expire.
+
+Delete an asset with `asset.delete()`, or by id alone with
+`client.assets.delete(asset_id)`:
+
+```python
+asset.delete()
+# or, without holding a handle:
+client.assets.delete(asset_id)
+```
+
+Deletion needs a proxy new enough to serve `DELETE /api/v2/assets/{id}` — an
+older [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy)
+returns `405` instead. (`AsyncAsset.delete()` / `AsyncAssetFactory.delete()`
+mirror both with `await`.)
+
 ## Live progress
 
 ```python
@@ -182,6 +201,27 @@ live UI feedback, and `wait()`/`result()`/`run()` for the definitive answer.
 output handles regardless of which node produced them (`job.get_outputs(node_id)`
 filters to one node, as in the quickstart above).
 
+## Getting a job's workflow back
+
+The SDK only holds the workflow it submitted for as long as the originating
+`Job` handle stays alive — for a job rehydrated purely by id
+(`client.jobs.get(job_id)`), `get_workflow()` is the only way to see the
+graph:
+
+```python
+job = client.jobs.get(job_id)
+wf = job.get_workflow()
+match wf.format:
+    case "api":   ...   # the executed graph; frontend-only nodes already resolved away
+    case "save":  ...   # the authoring workflow at the pinned version, canvas layout intact
+```
+
+`format` discriminates the shape of `wf.graph`, so branch on it rather than
+assume one. It depends on how the job was submitted, not on anything a caller
+controls — jobs submitted through this SDK always get `"api"` today, since v2
+submission has no version-pinning fields yet. (`AsyncJob.get_workflow()`
+mirrors this with `await`.)
+
 ## Downloading outputs
 
 A finished job exposes its results as `Output` handles — `job.outputs`, or
@@ -194,6 +234,9 @@ out.to_file("result.png")                   # stream to disk in chunks
 data = out.to_bytes()                       # buffer into memory
 out.to_file("head.png", range=(0, 1023))    # range-aware: first 1 KiB only
 ```
+
+Every output also carries `job_id`, the id of the job that produced it — so a
+caller holding just an output can get back to the job that made it.
 
 `get_download_url()` hands back a fetchable URL instead of transferring the
 bytes through your process — give it to a browser, a CDN, or another service:


### PR DESCRIPTION
`comfy-sdk` **0.1.8** shipped three capabilities the README never mentions. A stale reference doc in a published package is worse than a missing one.

## Added

- **Getting a job's workflow back** — `get_workflow()` on both clients, the `format` discriminator (`api` vs `save`), and why this is the only way to see the graph behind a job rehydrated by id. It states plainly that submissions from this SDK always get `api` today, since v2 has no version-pinning fields yet.
- **Asset deletion** — `asset.delete()` and `client.assets.delete(id)`, noting it needs a proxy new enough to serve `DELETE /api/v2/assets/{id}`; older ones return `405`.
- **`job_id` and `expires_at`** — on assets and outputs, including that `job_id` is `None` for an uploaded asset, which has no producing job.

## How it was checked

Every claim was read against the source behind it, not the changelog. The runnable parts were executed against the installed package — including confirming the pre-`COMFY_BASE_URL` positional call really does raise `TypeError`, since a sibling doc shipped examples that didn't.

The rest of the README was audited at the same time and found **accurate**: install requirements against `pyproject.toml`, the `COMFY_BASE_URL` and keyword-only `api_key` behaviour, the partner-node key distinction, `client_info`/User-Agent, the typed-exception list against `exceptions.py`'s map (exact match), the two-layer architecture description, and the release commands against CI.

`pytest` 140 passed / 4 skipped; ruff, ruff format, mypy, and the public-repo hygiene check all clean.

## Two things found but deliberately not changed

- **`Job.cancel()` and `Job.refresh()` have no README mention.** Not stale, just absent, and the README already omits other real methods. Worth a decision on whether this doc aims at full method coverage.
- **`AsyncOutput` has no `to_stream()`, while `Output` does.** That's a code asymmetry rather than a doc bug, so it stayed out of a docs-only change — but it makes the docs-site claim that the sync and async clients have "the same surface" untrue by exactly one method. Filed here so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for asset metadata, expiration details, and deletion options.
  * Documented compatibility with proxies and asynchronous asset operations.
  * Added instructions for retrieving job workflows and using supported workflow formats.
  * Explained how output handles identify the job that produced them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->