### PR TITLE
docs: document from_json/from_str and kind-typed outputs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ for output in job.get_outputs("9"):
     output.to_file(output.name)
 ```
 
+### Constructing a workflow
+
+`client.workflows` builds a `Workflow` from wherever your API-format graph already lives. All three constructors are local — none of them touches the network:
+
+| Constructor | Takes |
+|---|---|
+| `from_file(path)` | a path to a `workflow_api.json` on disk |
+| `from_json(graph)` | a graph already in memory, as a `dict` |
+| `from_str(text)` | the JSON text of a graph |
+
+Callers that assemble the graph in code — a service or a cron with no JSON file to ship alongside it — want `from_json`:
+
+```python
+graph = {                                   # API format, same shape as workflow_api.json (abridged)
+    "3": {"class_type": "KSampler", "inputs": {"seed": 0, "steps": 20}},
+    "9": {"class_type": "SaveImage", "inputs": {"images": ["8", 0]}},
+}
+
+wf = client.workflows.from_json(graph)      # or from_str(json.dumps(graph))
+wf.set_input("3", "seed", 42)               # sugar for graph["3"]["inputs"]["seed"] = 42
+
+job = client.run(wf)
+data = job.get_outputs("9")[0].to_bytes()   # bytes in memory, no file written
+```
+
+`from_json` wraps the dict you hand it rather than copying, and `wf.json` *is* that graph — still a plain, freely-mutable `dict` if you'd rather edit it directly than go through `set_input`. `AsyncComfy` exposes the same three constructors on `client.workflows`.
+
 ## Authentication — one client, per-surface key
 
 | Surface | `api_key` |
@@ -249,8 +276,26 @@ On Comfy Cloud / serverless the URL is a short-lived, **self-authorizing**
 signed storage URL: whoever holds it can read the asset until `expires_at`
 with no API key of their own. On a self-hosted proxy it's the content endpoint
 (normal auth still applies) and `expires_at` is `None`. It works on every
-backend and never downloads the bytes first. (`AsyncOutput` mirrors all of the
-above with `await`.)
+backend and never downloads the bytes first.
+
+### Outputs are kind-typed
+
+Outputs aren't assumed to be images. `output.type` is the normalized kind of what the node produced — one of `image`, `video`, `audio`, `text`, `file`, `latent` — and sits alongside `output.content_type` (the exact MIME type), `output.name` and `output.size_bytes`. Branch on it rather than sniffing the filename:
+
+```python
+for out in job.outputs:
+    match out.type:
+        case "image":
+            out.to_file(out.name)                        # stream straight to disk
+        case "audio":
+            transcode(out.to_bytes(), out.content_type)  # bytes in memory, nothing written
+        case "video":
+            enqueue(out.get_download_url().url)          # hand the URL off, transfer nothing
+        case _:
+            print(out.type, out.name, out.size_bytes)
+```
+
+(`AsyncOutput` mirrors all of the above with `await`.)
 
 ## Sync and async
 


### PR DESCRIPTION
## ELI-5

The README only ever showed one way to build a workflow — load `workflow_api.json` off disk — and only ever showed saving an image to a file. The SDK can do more than that: you can hand it a graph you built in code, and outputs tell you whether they're an image, a video, audio or text so you can pull them as raw bytes or as a link instead of a file. None of that was written down, so anyone integrating had to read the SDK source to find it. This writes it down. Docs only — no code changed.

## What changed

**Getting started → new "Constructing a workflow" subsection.** A three-row table covering `from_file(path)` / `from_json(graph)` / `from_str(text)`, a note that all three are local (no network I/O), and a worked example that builds a graph as a `dict`, calls `set_input` on it, submits with `client.run`, and pulls the result with `to_bytes()` — the headless/cron shape with no filesystem round-trip. It also states that `from_json` wraps the dict rather than copying it (so `wf.json` *is* your graph and stays freely mutable), and that `AsyncComfy` exposes the same three constructors.

**Downloading outputs → new "Outputs are kind-typed" subsection.** `output.type` is documented as the normalized kind, alongside `content_type` / `name` / `size_bytes`, with an example that branches across kinds and uses a different retrieval path for each: `to_file` for image, `to_bytes` for audio, `get_download_url()` for video, and a `case _` fallback. `to_bytes()` and `get_download_url()` themselves were already documented (#50/#51); what was missing was the kind discriminator and any non-image example — before this, the README's only mentions of audio or video were zero.

## Verification

`ruff check .`, `ruff format --check .`, `mypy src`, `pytest` — all green (140 passed, 4 skipped; the skips are the pre-existing integration tests).

Beyond the suite, every claim the new prose makes was exercised rather than asserted. I wrote a throwaway pytest module that runs the new snippets verbatim against the repo's own stub server and deleted it before committing (this is a docs-only PR, so it is not in the diff). It confirmed: `from_json` wraps without copying (`wf.json is graph`), `set_input` mutates that same dict, `from_str` round-trips the JSON text, `to_bytes()` returns the served bytes, and a job carrying four outputs typed `image` / `audio` / `video` / `text` dispatches correctly through the `match` in the example, including `get_download_url().url`.

The same names were then checked against the **published 0.1.8** release (not just this tree), since the acceptance bar is that the examples work on the current published 0.1.x: `WorkflowFactory` has all three constructors, `Output` has `to_file` / `to_stream` / `to_bytes` / `get_download_url` / `type` / `content_type` / `name` / `size_bytes`, and `OutputType` is the same six-value enum.

## Judgment calls

**Six kinds, not four.** The brief I worked from named the kinds as `image | video | audio | text`. The source of truth — the `OutputType` enum generated from `spec/openapi.yaml` — has six: `image`, `video`, `audio`, `text`, `file`, `latent`. I documented the six that exist. The `case _` fallback in the example is deliberate for the same reason: the README isn't covered by the codegen drift check, so a reader who copies the snippet still handles a kind added later.

**The example graph is abridged and says so.** A genuinely runnable API-format graph is roughly seven nodes of checkpoint/CLIP/latent plumbing, which would bury the point of the snippet. It is labelled `(abridged)`; node `9` references a node `8` that isn't shown.

## Not covered by this PR

- **`Output.to_stream()` is still undocumented, deliberately.** It has no async twin — `AsyncOutput.to_stream` does not exist on 0.1.8 or on this tree — and the outputs section closes with "`AsyncOutput` mirrors all of the above with `await`", which documenting it there would make false. Writing it up properly means either adding the async method or carving out an exception, and both are outside a docs-only change.
- **Five other public members remain unmentioned in the README.** Sizing the portion this PR does *not* cover: a word-boundary text sweep of every public method and property on the `comfy_sdk` classes against the README says **6 of 41 distinct names go unmentioned after this change** (`aclose`, `as_reference`, `close`, `created_new`, `refresh`, and the `to_stream` above), **down from 10 before it** (`content_type`, `from_json`, `from_str` and `size_bytes` are the four this PR adds). The sweep is coarse — it matches bare words, so a name like `type` counts as mentioned wherever the English word appears — but it is symmetric across both revisions.
- **Two artifacts named by my source task could not be read from this environment and are therefore unexercised**: an internal tracking issue for a downstream Python consumer migration (the case that motivated this), and a sibling issue filed against the TypeScript SDK. Both live on an internal tracker with no access from here, so I could not confirm whether either constrains the wording beyond what's above. Nothing in this diff depends on them — it is grounded in `src/comfy_sdk/workflows.py`, `src/comfy_sdk/outputs.py` and the generated `OutputType` — but they are named here rather than assumed away.
