### PR TITLE
ci: add the team-gated Cursor review caller

### DIFF
--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -1,0 +1,56 @@
+# Description: Team-gated multi-model Cursor review — a thin caller for the
+# reusable workflow in Comfy-Org/github-workflows, which is the single source of
+# truth for the panel, judge, prompts, and scripts. Triggered by the
+# 'cursor-review' label.
+#
+# Access control (team-only, two layers):
+#   1. Only users with triage permission or higher can apply a label in a public
+#      repo, so the public cannot trigger this.
+#   2. The reusable workflow's secret-bearing jobs do not run on fork PRs (forks
+#      get no secrets), so CURSOR_API_KEY is reachable only on internal branches.
+name: CI - Cursor Review
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Re-labeling cancels an in-flight run for the same PR + label.
+  group: cursor-review-pr-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  cursor-review:
+    if: github.event.action == 'labeled' && github.event.label.name == 'cursor-review'
+    # SHA-pinned. Bump this SHA to pick up upstream changes; keep
+    # `workflows_ref` matching so prompts/scripts load from the same commit as
+    # the workflow definition.
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@6a374b7c0d6ea603dad12a7dcbf80e6d65e314e1 # github-workflows main (6a374b7)
+    with:
+      # Overriding diff_excludes replaces the reusable default wholesale, so
+      # this restates the generated/vendored defaults and adds this repo's
+      # generated and heavy paths.
+      diff_excludes: >-
+        :!**/package-lock.json
+        :!**/yarn.lock
+        :!**/pnpm-lock.yaml
+        :!**/node_modules/**
+        :!**/.claude/**
+        :!**/dist/**
+        :!**/vendor/**
+        :!**/*.generated.*
+        :!**/*.min.js
+        :!**/*.min.css
+        :!uv.lock
+        :!assets/**
+        :!src/comfy_low/models/**
+      # Load the prompts/scripts from the same ref as `uses:`.
+      workflows_ref: 6a374b7c0d6ea603dad12a7dcbf80e6d65e314e1
+    secrets:
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      # Optional — enables start/complete Slack DMs to the triggerer.
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -25,29 +25,45 @@ concurrency:
 
 jobs:
   cursor-review:
-    if: github.event.action == 'labeled' && github.event.label.name == 'cursor-review'
+    # No job-level `if` on purpose: label filtering belongs to the reusable
+    # workflow's Gate, which knows the `review_label` input and also implements
+    # the unblock path (removing `skip-cursor-review` while `cursor-review` is
+    # still applied re-triggers the review). Filtering `unlabeled` out here
+    # would kill that path and hardcode a label name the reusable already owns.
+    # The Gate no-ops in a couple of seconds on labels it doesn't care about.
+    #
     # SHA-pinned. Bump this SHA to pick up upstream changes; keep
     # `workflows_ref` matching so prompts/scripts load from the same commit as
     # the workflow definition.
     uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@6a374b7c0d6ea603dad12a7dcbf80e6d65e314e1 # github-workflows main (6a374b7)
     with:
-      # Overriding diff_excludes replaces the reusable default wholesale, so
-      # this restates the generated/vendored defaults and adds this repo's
-      # generated and heavy paths.
-      diff_excludes: >-
-        :!**/package-lock.json
-        :!**/yarn.lock
-        :!**/pnpm-lock.yaml
-        :!**/node_modules/**
-        :!**/.claude/**
-        :!**/dist/**
-        :!**/vendor/**
-        :!**/*.generated.*
-        :!**/*.min.js
-        :!**/*.min.css
-        :!uv.lock
-        :!assets/**
-        :!src/comfy_low/models/**
+      # Repo-specific generated/heavy paths. `extra_generated_globs` is the
+      # right knob rather than `diff_excludes`: it feeds the shared
+      # check-pr-size classifier, so matching files stay out of BOTH the diff
+      # handed to the panel AND the `diff_size_cap` count. `diff_excludes`
+      # filters only the reviewed patch, so a large regeneration listed there
+      # would be hidden from the panel yet still counted toward the cap —
+      # tripping it and skipping the whole review.
+      #
+      # Supplying this input REPLACES the upstream default list, so the
+      # defaults are restated verbatim before this repo's own paths. These are
+      # plain globs, not git pathspecs (no `:!` prefix — that is
+      # `diff_excludes`' syntax). A pattern containing `/` is anchored to the
+      # whole repo-relative path unless it opens with `**/`.
+      #
+      # Not restated: the eight dependency lockfiles (uv.lock included) are
+      # classifier built-ins already. Only `_generated.py` is machine-produced
+      # by scripts/gen_models.sh — the sibling `__init__.py` is hand-written and
+      # must stay visible to the panel.
+      extra_generated_globs: >-
+        **/node_modules/**
+        **/dist/**
+        **/vendor/**
+        **/*.generated.*
+        **/*.min.js
+        **/*.min.css
+        src/comfy_low/models/_generated.py
+        assets/**
       # Load the prompts/scripts from the same ref as `uses:`.
       workflows_ref: 6a374b7c0d6ea603dad12a7dcbf80e6d65e314e1
     secrets:

--- a/scripts/check_public_repo_hygiene.py
+++ b/scripts/check_public_repo_hygiene.py
@@ -86,9 +86,10 @@ PUBLIC_COMFY_ORG_REPOS = {
     "ComfyUI",
     # Reusable GitHub Actions workflows (cursor-review and friends). Verified
     # public: `gh repo view Comfy-Org/github-workflows` reports
-    # visibility=PUBLIC. It has to be public for a `uses:` reference from this
-    # repo to resolve at all -- a private reusable workflow would fail the run,
-    # so a passing cursor-review run is itself evidence of its visibility.
+    # visibility=PUBLIC. That check is the ONLY basis for an entry here -- a
+    # resolving `uses:` reference is not evidence, because a private repo can
+    # share its reusable workflows org-internally (Settings > Actions > access),
+    # so a passing run says nothing about visibility.
     "github-workflows",
 }
 # CODEOWNERS team handles (`@Comfy-Org/<team>`) are inherently public on a

--- a/scripts/check_public_repo_hygiene.py
+++ b/scripts/check_public_repo_hygiene.py
@@ -84,6 +84,12 @@ PUBLIC_COMFY_ORG_REPOS = {
     "comfy-typescript-sdk",
     "ComfyUI_frontend",
     "ComfyUI",
+    # Reusable GitHub Actions workflows (cursor-review and friends). Verified
+    # public: `gh repo view Comfy-Org/github-workflows` reports
+    # visibility=PUBLIC. It has to be public for a `uses:` reference from this
+    # repo to resolve at all -- a private reusable workflow would fail the run,
+    # so a passing cursor-review run is itself evidence of its visibility.
+    "github-workflows",
 }
 # CODEOWNERS team handles (`@Comfy-Org/<team>`) are inherently public on a
 # public repo -- GitHub renders the CODEOWNERS owners to anyone who can see the


### PR DESCRIPTION
## ELI-5

Every actively-developed repo in the org gets an automated code review when you put a `cursor-review` label on a PR. This repo was missing the file that switches that on, so its PRs never got one. This adds it.

## What this is

A thin caller for the reusable `cursor-review` workflow in `Comfy-Org/github-workflows`, which owns the review panel, the judge, the prompts and the scripts. The caller carries no logic of its own — it pins a SHA and passes repo-specific settings.

Copied from the callers in `comfy-cli` / `comfy-toolbox` / `evals` and adjusted for this repo. The `cursor-review` label already exists here, so nothing else needs creating.

## Why now

This repo was just made routable for automated code work, and it is about to receive its first agent-authored PRs. Landing the review caller **before** that work arrives means those PRs get a review pass from the outset rather than retroactively — and this PR is itself a deliberately small first change to prove the path.

## Repo-specific tuning

Generated and heavy paths are passed via **`extra_generated_globs`**, not `diff_excludes`. The distinction is load-bearing: `diff_excludes` filters only the patch handed to the review panel, while `extra_generated_globs` feeds the shared `check-pr-size` classifier that drives **both** the reviewed diff and the `diff_size_cap` count. Listing a generated path under `diff_excludes` would hide it from the reviewers *and still count it* toward the cap — so a routine regeneration would trip the cap and skip the entire review.

`extra_generated_globs` does replace its upstream default wholesale, so the shared defaults (`node_modules`, `dist`, `vendor`, `*.generated.*`, minified output) are restated verbatim, plus:

- `src/comfy_low/models/_generated.py` — the pydantic models emitted from `spec/openapi.yaml` by `scripts/gen_models.sh`. Scoped to that one file, not the package: the sibling `__init__.py` is hand-written (re-export list and `__all__`) and must stay visible to the panel.
- `assets/**`

Dependency lockfiles including `uv.lock` are **not** restated — the classifier covers eight of them as built-ins.

The generated file is the one that matters. Without it, a routine regeneration would bury a review in machine-written diff and the signal would be lost.

Label filtering is delegated entirely to the reusable workflow's Gate — the caller carries no job-level `if`. The Gate owns the `review_label` input and implements the unblock path (removing `skip-cursor-review` while `cursor-review` is still applied re-triggers the review), and every downstream job is already gated on `needs.gate.outputs.should_run`, so filtering in the caller would only break those behaviours.

## Access control

Two layers, both inherited from the reusable workflow's design:

1. Applying a label in a public repo requires **triage permission or higher**, so the public cannot trigger this.
2. The secret-bearing jobs **do not run on fork PRs** (forks receive no secrets), so `CURSOR_API_KEY` is only reachable from internal branches.

Permissions are `contents: read` + `pull-requests: write` — no write access to code.

## Verification

The workflow YAML parses, the pin is the current `github-workflows` `main` (`6a374b7`), and `workflows_ref` matches the `uses:` SHA so prompts and scripts load from the same commit as the definition.

**The open question is answered.** The original concern was that `CURSOR_API_KEY` is an org-level secret whose visibility (all repositories vs. a selected list) could not be read without `admin:org`. Applying the label to this PR settled it empirically: the full panel ran green here — 8 review cells across 4 labs, plus preflight, ledger, consolidate and the Slack notifications — so the secret is visible to this repo and no org-admin change is needed.

## Provenance

**Authored by:** agent-work loop

**Verified:** `ruff check .`, `ruff format --check .`, `mypy src` and `pytest` all pass locally (140 passed, 4 skipped); `python3 scripts/check_public_repo_hygiene.py` reports no internal-only references; the workflow YAML parses under `yaml.safe_load`; `gh repo view Comfy-Org/github-workflows --json visibility` returns `PUBLIC`, which is the sole basis for the hygiene allowlist entry. The `extra_generated_globs` / `diff_excludes` semantics, the Gate's label and unblock branches, and the `needs.gate.outputs.should_run` guard on every downstream job were each read directly from the reusable workflow at the pinned SHA `6a374b7`, not assumed. The full PR check rollup is green.

**Deviations:** One review finding was deferred rather than fixed. A PR opened with the `cursor-review` label already applied may never be reviewed, because the Gate only accepts `action == labeled`. There is no caller-side fix — adding `opened` to `types` reaches the Gate with an empty `label.name` and falls through — so closing it requires a change to the shared reusable workflow that affects every consumer repo. It is proposed as a follow-up for triage; the workaround is to remove and re-add the label. All other findings from the review panel were fixed in `5033278`.
