### PR TITLE
feat: resolve the API key from api_key= then COMFY_API_KEY, with a clear local error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,26 @@ notes for each version.
 
 ## [Unreleased]
 
-_Nothing yet — add an entry here when your change lands._
+### Added
+
+- Credential resolution with a documented order: the explicit `api_key=`
+  argument first, then the `COMFY_API_KEY` environment variable. Against Comfy
+  Cloud, which always requires a key, neither raises the new `MissingApiKey`
+  locally at construction — naming `COMFY_API_KEY` in the message — instead of
+  costing a round trip to be told `401`. Both sources are trimmed, and a blank
+  value counts as unset.
+- `MissingApiKey` (a `ComfyError`, `code="missing_api_key"`) and
+  `API_KEY_ENV_VAR` are exported from `comfy_sdk`.
+- `Comfy`/`AsyncComfy` now have an explicit `repr()` reporting the base URL and
+  `authenticated=True|False`. The key is never rendered, logged, or included in
+  an exception message.
+
+### Changed
+
+- A client targeting a deployment named by `COMFY_BASE_URL` is unchanged: with
+  no key resolved it is still built without one and still sends no credentials,
+  which is what a self-hosted ComfyUI behind the API proxy needs. Only the Comfy
+  Cloud default gained the local error.
 
 ## [0.1.8] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,19 @@ notes for each version.
   Cloud, which always requires a key, neither raises the new `MissingApiKey`
   locally at construction — naming `COMFY_API_KEY` in the message — instead of
   costing a round trip to be told `401`. Both sources are trimmed, and a blank
-  value counts as unset.
+  value counts as unset. Comfy Cloud is recognized by normalized origin (scheme,
+  host, effective port) and path rather than by string, so a `COMFY_BASE_URL`
+  that spells it differently — `https://cloud.comfy.org:443/`, or with a
+  mixed-case host — gets the same local error rather than a server `401`.
 - `MissingApiKey` (a `ComfyError`, `code="missing_api_key"`) and
   `API_KEY_ENV_VAR` are exported from `comfy_sdk`.
 - `Comfy`/`AsyncComfy` now have an explicit `repr()` reporting the base URL and
   `authenticated=True|False`. The key is never rendered, logged, or included in
-  an exception message.
+  an exception message. A credential embedded in the base URL itself
+  (`COMFY_BASE_URL=https://user:token@proxy.example`, for a deployment behind an
+  authenticating proxy) is redacted to `***@host` in every `repr()` — the
+  client, its transport and its `models` namespace — while requests still go out
+  against the URL exactly as given.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,56 @@ aimed at the target deployment's own origin — a server-returned follow-up link
 (`job.urls.self`/`cancel`/`events`, or a redirected asset download) pointing
 anywhere else never receives it.
 
+### Where the key comes from
+
+Each client resolves its credential once, at construction, in a fixed order:
+
+1. the explicit **`api_key=` argument** — it always wins;
+2. the **`COMFY_API_KEY` environment variable**, when no argument was passed;
+3. neither → **`MissingApiKey`**, raised locally against Comfy Cloud, which
+   always requires a key. Nothing is sent, so you find out from the constructor
+   rather than from a `401` on your first call.
+
+```bash
+export COMFY_API_KEY="comfyui-..."
+```
+
+```python
+client = Comfy()                        # uses COMFY_API_KEY
+client = Comfy(api_key="comfyui-...")   # this key, whatever the environment says
+```
+
+Both sources are read fresh on every construction (so a process can build
+successive clients under different credentials), and both are trimmed — leading
+and trailing whitespace is stripped, and a blank value counts as *unset*, so
+`COMFY_API_KEY=` in a shell profile and a key read from a file with a trailing
+newline both do the obvious thing.
+
+Step 3 applies only to Comfy Cloud. A deployment named by `COMFY_BASE_URL` may
+have no auth at all, so if nothing resolves there the client is built without a
+credential and sends none — the self-hosted row of the table above is unchanged.
+A serverless deployment does require a key, and picks up `COMFY_API_KEY` the
+same way; supply one or the server will answer `401`.
+
+The key is write-only from the outside: it is never logged, never rendered by a
+client's `repr()`/`str()` (they report `authenticated=True|False`, never the
+key), and never placed in an exception message.
+
+`MissingApiKey` is a `ComfyError` like every other SDK exception, and is
+distinct from `Unauthorized` — no key at all, versus a key the server rejected:
+
+```python
+from comfy_sdk import Comfy, MissingApiKey
+
+try:
+    client = Comfy()
+except MissingApiKey as exc:
+    print(exc)   # names COMFY_API_KEY and the api_key= argument
+```
+
+The low-level `comfy_low.ComfyLow` transport is unaffected: it takes the key it
+is handed and reads no environment, since resolution is a `comfy_sdk` concern.
+
 ### Targeting another deployment
 
 `Comfy()` points at Comfy Cloud and takes no base-URL argument. To run against

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ and trailing whitespace is stripped, and a blank value counts as *unset*, so
 `COMFY_API_KEY=` in a shell profile and a key read from a file with a trailing
 newline both do the obvious thing.
 
-Step 3 applies only to Comfy Cloud. A deployment named by `COMFY_BASE_URL` may
+Step 3 applies only to Comfy Cloud, recognized by its normalized origin and
+path rather than by the exact string — `https://cloud.comfy.org:443/` is the
+same deployment and gets the same local error. A deployment named by `COMFY_BASE_URL` may
 have no auth at all, so if nothing resolves there the client is built without a
 credential and sends none — the self-hosted row of the table above is unchanged.
 A serverless deployment does require a key, and picks up `COMFY_API_KEY` the
@@ -148,7 +150,10 @@ same way; supply one or the server will answer `401`.
 
 The key is write-only from the outside: it is never logged, never rendered by a
 client's `repr()`/`str()` (they report `authenticated=True|False`, never the
-key), and never placed in an exception message.
+key), and never placed in an exception message. The same holds for a credential
+carried in the base URL itself — `COMFY_BASE_URL=https://user:token@proxy.example`
+reaches a deployment behind an authenticating proxy, and every `repr()` renders
+it as `https://***@proxy.example` while requests still use the URL as given.
 
 `MissingApiKey` is a `ComfyError` like every other SDK exception, and is
 distinct from `Unauthorized` — no key at all, versus a key the server rejected:

--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -104,6 +104,13 @@ class _Prepared:
         self._origin_url = f"{parts.scheme}://{parts.netloc}"
         self._user_agent = _build_user_agent(client_info)
 
+    def __repr__(self) -> str:
+        # This object holds the bearer token, so its repr is written out rather
+        # than inherited: `authenticated` reports only whether one is set.
+        return (
+            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={bool(self.api_key)})"
+        )
+
     def url(self, path: str) -> str:
         # A server link (job.urls.*, marked by containing /api/) already carries
         # the server's mount prefix, so it resolves against the origin — joining
@@ -217,6 +224,20 @@ class ComfyLow:
     def timeout(self) -> httpx.Timeout:
         """The httpx client's default timeout. A per-request ``timeout=`` still wins."""
         return self._client.timeout
+
+    @property
+    def authenticated(self) -> bool:
+        """Whether a credential is attached to same-origin requests.
+
+        The key itself is deliberately not exposed here: this is the read a
+        layer above (or a ``repr``) needs, and it cannot leak the credential.
+        """
+        return bool(self._p.api_key)
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={self.authenticated})"
+        )
 
     # -- lifecycle --------------------------------------------------------
     def close(self) -> None:
@@ -517,6 +538,16 @@ class AsyncComfyLow:
     def timeout(self) -> httpx.Timeout:
         """The httpx client's default timeout. A per-request ``timeout=`` still wins."""
         return self._client.timeout
+
+    @property
+    def authenticated(self) -> bool:
+        """Whether a credential is attached — mirrors :attr:`ComfyLow.authenticated`."""
+        return bool(self._p.api_key)
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={self.authenticated})"
+        )
 
     async def aclose(self) -> None:
         if self._own_client:

--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any, BinaryIO
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 import httpx
 
@@ -127,8 +127,15 @@ def _retry_after(resp: httpx.Response) -> int | None:
         return None
 
 
-def _origin(url: str) -> tuple[str, str, int | None]:
-    """Normalized ``(scheme, host, port)`` — the parts that define same-origin."""
+def origin(url: str) -> tuple[str, str, int | None]:
+    """Normalized ``(scheme, host, port)`` — the parts that define same-origin.
+
+    Public because it is the single definition of "same target" in the SDK: the
+    transport decides here whether a URL may carry the bearer token, and
+    ``comfy_sdk.client`` compares against it to recognize Comfy Cloud however
+    the caller spelled it. Two spellings that differ only in case or in an
+    explicitly written default port are the same origin.
+    """
     parts = urlsplit(url)
     scheme = (parts.scheme or "").lower()
     port = parts.port
@@ -137,22 +144,44 @@ def _origin(url: str) -> tuple[str, str, int | None]:
     return (scheme, (parts.hostname or "").lower(), port)
 
 
+def redact_userinfo(url: str) -> str:
+    """``url`` with any userinfo replaced by ``***`` — the form safe to render.
+
+    A base URL may legitimately carry credentials in its netloc
+    (``https://user:token@proxy.example`` for an authenticating proxy), and a
+    client is exactly the object that ends up in a traceback, a debugger frame
+    or a CI log. So every ``repr`` renders this form while the URL the
+    transport actually requests against keeps the userinfo intact — the
+    credential is hidden from display, not taken away from the caller.
+    """
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, f"***@{host}", parts.path, parts.query, parts.fragment))
+
+
 class _Prepared:
     """Sans-IO request building shared by both transports."""
 
     def __init__(self, base_url: str, api_key: str | None, client_info: str | None = None) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
-        self._base_origin = _origin(self.base_url)
+        #: ``base_url`` with any userinfo redacted — what every ``repr`` shows.
+        self.safe_base_url = redact_userinfo(self.base_url)
+        self._base_origin = origin(self.base_url)
         parts = urlsplit(self.base_url)
         self._origin_url = f"{parts.scheme}://{parts.netloc}"
         self._user_agent = _build_user_agent(client_info)
 
     def __repr__(self) -> str:
         # This object holds the bearer token, so its repr is written out rather
-        # than inherited: `authenticated` reports only whether one is set.
+        # than inherited: `authenticated` reports only whether one is set, and
+        # the base URL is the redacted form so a credential embedded *in it*
+        # does not leak either.
         return (
-            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={bool(self.api_key)})"
+            f"{type(self).__name__}(base_url={self.safe_base_url!r}, "
+            f"authenticated={bool(self.api_key)})"
         )
 
     def url(self, path: str) -> str:
@@ -175,7 +204,7 @@ class _Prepared:
         # server-returned absolute follow-up links (job.urls.self/cancel/events)
         # must not carry the key to a different scheme/host/port. Relative paths
         # are always resolved under base_url, so they are unaffected.
-        if self.api_key and _origin(url) == self._base_origin:
+        if self.api_key and origin(url) == self._base_origin:
             h["Authorization"] = f"Bearer {self.api_key}"
         if extra:
             h.update(extra)
@@ -265,6 +294,11 @@ class ComfyLow:
         return self._p.base_url
 
     @property
+    def safe_base_url(self) -> str:
+        """:attr:`base_url` with any userinfo redacted — the form safe to log."""
+        return self._p.safe_base_url
+
+    @property
     def timeout(self) -> httpx.Timeout:
         """The httpx client's default timeout. A per-request ``timeout=`` still wins."""
         return self._client.timeout
@@ -280,7 +314,8 @@ class ComfyLow:
 
     def __repr__(self) -> str:
         return (
-            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={self.authenticated})"
+            f"{type(self).__name__}(base_url={self.safe_base_url!r}, "
+            f"authenticated={self.authenticated})"
         )
 
     # -- lifecycle --------------------------------------------------------
@@ -604,6 +639,11 @@ class AsyncComfyLow:
         return self._p.base_url
 
     @property
+    def safe_base_url(self) -> str:
+        """:attr:`base_url` with any userinfo redacted — the form safe to log."""
+        return self._p.safe_base_url
+
+    @property
     def timeout(self) -> httpx.Timeout:
         """The httpx client's default timeout. A per-request ``timeout=`` still wins."""
         return self._client.timeout
@@ -615,7 +655,8 @@ class AsyncComfyLow:
 
     def __repr__(self) -> str:
         return (
-            f"{type(self).__name__}(base_url={self.base_url!r}, authenticated={self.authenticated})"
+            f"{type(self).__name__}(base_url={self.safe_base_url!r}, "
+            f"authenticated={self.authenticated})"
         )
 
     async def aclose(self) -> None:

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -14,8 +14,9 @@ Quickstart::
     from comfy_sdk import Comfy
 
     client = Comfy(api_key="comfyui-...")              # Comfy Cloud
-    # export COMFY_BASE_URL=http://127.0.0.1:8189      # self-hosted, no key
-    # client = Comfy()
+    # export COMFY_API_KEY=comfyui-...                 # ...or from the environment
+    # client = Comfy()                                 # explicit key wins over it
+    # export COMFY_BASE_URL=http://127.0.0.1:8189      # self-hosted, no key needed
 
     wf = client.workflows.from_file("workflow_api.json")
     asset = client.assets.from_file("photo.png")       # lazy; uploaded on use
@@ -31,7 +32,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 from .assets import Asset, AssetFactory, AsyncAsset, AsyncAssetFactory
-from .client import BASE_URL_ENV_VAR, COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
+from .client import API_KEY_ENV_VAR, BASE_URL_ENV_VAR, COMFY_CLOUD_BASE_URL, AsyncComfy, Comfy
 from .events import (
     Event,
     Log,
@@ -49,6 +50,7 @@ from .exceptions import (
     InsufficientCredits,
     InvalidWorkflow,
     JobFailed,
+    MissingApiKey,
     MissingAsset,
     NotFound,
     QueueFull,
@@ -72,6 +74,7 @@ __all__ = [
     "Comfy",
     "COMFY_CLOUD_BASE_URL",
     "BASE_URL_ENV_VAR",
+    "API_KEY_ENV_VAR",
     "AsyncComfy",
     # assets / workflows / jobs / outputs
     "Asset",
@@ -105,6 +108,7 @@ __all__ = [
     "IdempotencyKeyReuse",
     "InsufficientCredits",
     "NotFound",
+    "MissingApiKey",
     "Unauthorized",
     "Forbidden",
 ]

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -36,7 +36,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from comfy_low.errors import ApiError
-from comfy_low.transport import AsyncComfyLow, ComfyLow
+from comfy_low.transport import AsyncComfyLow, ComfyLow, origin
 
 from . import _core
 from .assets import AssetFactory, AsyncAssetFactory
@@ -111,6 +111,26 @@ def _resolve_base_url() -> str:
     return raw
 
 
+def _same_deployment(url: str, other: str) -> bool:
+    """Whether two base URLs name the same deployment.
+
+    Compared by normalized origin (scheme, host, effective port — shared with
+    the transport's same-origin credential rule) plus path, rather than by
+    string. ``https://cloud.comfy.org:443/`` is Comfy Cloud with its default
+    port written out, and reading it as *some other* deployment would hand the
+    caller a keyless client and a server 401 on the first request instead of
+    the local error this module promises.
+
+    The path is part of the comparison because a deployment mounted under the
+    same host (``https://cloud.comfy.org/self-hosted``) is a different target,
+    and the keyless carve-out has to keep applying to it.
+    """
+    return (origin(url), urlsplit(url).path.rstrip("/")) == (
+        origin(other),
+        urlsplit(other).path.rstrip("/"),
+    )
+
+
 def _resolve_api_key(explicit: str | None, base_url: str) -> str | None:
     """The explicit argument, then ``COMFY_API_KEY``, then a clear local error.
 
@@ -131,7 +151,7 @@ def _resolve_api_key(explicit: str | None, base_url: str) -> str | None:
     for candidate in (explicit, os.environ.get(API_KEY_ENV_VAR)):
         if candidate and candidate.strip():
             return candidate.strip()
-    if base_url.rstrip("/") == COMFY_CLOUD_BASE_URL:
+    if _same_deployment(base_url, COMFY_CLOUD_BASE_URL):
         raise MissingApiKey(
             f"no API key: pass api_key=... to the client, or set {API_KEY_ENV_VAR} in the "
             f"environment. Comfy Cloud ({COMFY_CLOUD_BASE_URL}) requires one; set "
@@ -202,7 +222,7 @@ class Comfy:
         purpose instead of left to whoever edits this class next.
         """
         return (
-            f"{type(self).__name__}(base_url={self._low.base_url!r}, "
+            f"{type(self).__name__}(base_url={self._low.safe_base_url!r}, "
             f"authenticated={self._low.authenticated})"
         )
 
@@ -314,7 +334,7 @@ class AsyncComfy:
     def __repr__(self) -> str:
         """Key-free, exactly as :meth:`Comfy.__repr__`."""
         return (
-            f"{type(self).__name__}(base_url={self._low.base_url!r}, "
+            f"{type(self).__name__}(base_url={self._low.safe_base_url!r}, "
             f"authenticated={self._low.authenticated})"
         )
 

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -11,13 +11,21 @@ Both clients target Comfy Cloud. Another deployment — a self-hosted proxy or a
 serverless one — is selected through the ``COMFY_BASE_URL`` environment
 variable; there is no base-URL constructor parameter.
 
-Per-surface key behavior is inherited from ``comfy_low``: pass ``api_key`` to
-the constructor for Comfy Cloud / serverless; leave it unset for a self-hosted
-proxy that has no auth (no credentials are then sent). That constructor key is
-this client's own credential (sent as the ``Authorization`` bearer token) and
-is unrelated to the ``api_key`` accepted by ``submit``/``run``, which
-authenticates partner (API) nodes embedded in a workflow (e.g. Gemini) and is
-sent in the request body instead.
+Credentials resolve in a fixed order at construction: the explicit ``api_key``
+argument, then the ``COMFY_API_KEY`` environment variable, then — targeting
+Comfy Cloud, which always requires a key — a local :class:`MissingApiKey`
+naming that variable, raised before any request rather than surfacing as a
+server 401 on the first call. A deployment named by ``COMFY_BASE_URL`` may
+have no auth at all (a self-hosted ComfyUI behind the API proxy), so there an
+unresolved key stays valid and means "send no credentials". That constructor
+key is this client's own credential (sent as the ``Authorization`` bearer
+token) and is unrelated to the ``api_key`` accepted by ``submit``/``run``,
+which authenticates partner (API) nodes embedded in a workflow (e.g. Gemini)
+and is sent in the request body instead.
+
+The key itself is write-only from the outside: it is never logged, never
+rendered by a client's ``repr``/``str`` (which report only *whether* one is
+attached), and never placed in an exception message.
 """
 
 from __future__ import annotations
@@ -32,7 +40,7 @@ from comfy_low.transport import AsyncComfyLow, ComfyLow
 
 from . import _core
 from .assets import AssetFactory, AsyncAssetFactory
-from .exceptions import WorkflowFormatUi, to_sdk_error
+from .exceptions import MissingApiKey, WorkflowFormatUi, to_sdk_error
 from .jobs import AsyncJob, AsyncJobFactory, Job, JobFactory
 from .models import AsyncModels, Models
 from .workflows import Workflow, WorkflowFactory
@@ -43,6 +51,8 @@ _QUEUE_RETRY_BUDGET = 60.0
 COMFY_CLOUD_BASE_URL = "https://cloud.comfy.org"
 #: Environment variable that redirects a client at another deployment.
 BASE_URL_ENV_VAR = "COMFY_BASE_URL"
+#: Environment variable read when no ``api_key`` is passed to the constructor.
+API_KEY_ENV_VAR = "COMFY_API_KEY"
 
 _DEFAULT_RETRY_AFTER = 2
 _now = time.monotonic
@@ -101,6 +111,36 @@ def _resolve_base_url() -> str:
     return raw
 
 
+def _resolve_api_key(explicit: str | None, base_url: str) -> str | None:
+    """The explicit argument, then ``COMFY_API_KEY``, then a clear local error.
+
+    Read per construction (like the base URL) so one process can build
+    successive clients under different credentials. Surrounding whitespace is
+    stripped and a blank value counts as unset at either source, so
+    ``COMFY_API_KEY=`` in a shell profile — or a key read out of a file with a
+    trailing newline — behaves the way it looks.
+
+    Comfy Cloud always requires a key, so exhausting both sources there raises
+    :class:`~comfy_sdk.exceptions.MissingApiKey` *here*, with no network call
+    attempted: a missing credential reported as a server 401 sends the caller
+    looking at their key's validity instead of its absence. A deployment named
+    by ``COMFY_BASE_URL`` may legitimately have none (a self-hosted ComfyUI
+    behind the API proxy), so there an unresolved key is not an error and keeps
+    its documented meaning — send no credentials at all.
+    """
+    for candidate in (explicit, os.environ.get(API_KEY_ENV_VAR)):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    if base_url.rstrip("/") == COMFY_CLOUD_BASE_URL:
+        raise MissingApiKey(
+            f"no API key: pass api_key=... to the client, or set {API_KEY_ENV_VAR} in the "
+            f"environment. Comfy Cloud ({COMFY_CLOUD_BASE_URL}) requires one; set "
+            f"{BASE_URL_ENV_VAR} to target a deployment that does not.",
+            code="missing_api_key",
+        )
+    return None
+
+
 def _guard_ui_format(workflow: Workflow) -> None:
     if _core.looks_like_ui_format(workflow.json):
         raise WorkflowFormatUi(
@@ -116,7 +156,9 @@ class Comfy:
 
     Targets Comfy Cloud, or whatever deployment ``COMFY_BASE_URL`` names.
     ``api_key`` is keyword-only so a pre-``COMFY_BASE_URL`` positional URL
-    fails loudly instead of being read as a key.
+    fails loudly instead of being read as a key. Omit it to fall back to
+    ``COMFY_API_KEY``; against Comfy Cloud, neither raises
+    :class:`~comfy_sdk.exceptions.MissingApiKey` at construction.
     """
 
     def __init__(
@@ -126,7 +168,9 @@ class Comfy:
         timeout: float | None = 30.0,
         client_info: str | None = None,
     ) -> None:
-        self._low = ComfyLow(_resolve_base_url(), api_key, timeout=timeout, client_info=client_info)
+        base_url = _resolve_base_url()
+        key = _resolve_api_key(api_key, base_url)
+        self._low = ComfyLow(base_url, key, timeout=timeout, client_info=client_info)
         self.assets = AssetFactory(self._low)
         self.workflows = WorkflowFactory()
         self.jobs = JobFactory(self._low)
@@ -148,6 +192,19 @@ class Comfy:
 
     def __exit__(self, *exc: object) -> None:
         self.close()
+
+    def __repr__(self) -> str:
+        """Target and *whether* a key is attached — never the key itself.
+
+        Explicit rather than inherited: the default ``object`` repr happens not
+        to leak, but a client is exactly the object that ends up in a traceback,
+        a debugger frame, or a CI log, so what it renders is stated here on
+        purpose instead of left to whoever edits this class next.
+        """
+        return (
+            f"{type(self).__name__}(base_url={self._low.base_url!r}, "
+            f"authenticated={self._low.authenticated})"
+        )
 
     def _materialize(self, workflow: Workflow) -> dict[str, Any]:
         """Commit every embedded asset handle and substitute ``core/ASSET`` refs."""
@@ -221,7 +278,12 @@ def _run_with_timeout(job: Job, timeout: float) -> Job:
 
 
 class AsyncComfy:
-    """Asynchronous Comfy API v2 client — mirrors :class:`Comfy`."""
+    """Asynchronous Comfy API v2 client — mirrors :class:`Comfy`.
+
+    Same credential resolution (explicit ``api_key`` → ``COMFY_API_KEY`` →
+    :class:`~comfy_sdk.exceptions.MissingApiKey` on Comfy Cloud) and the same
+    key-free ``repr``.
+    """
 
     def __init__(
         self,
@@ -230,9 +292,9 @@ class AsyncComfy:
         timeout: float | None = 30.0,
         client_info: str | None = None,
     ) -> None:
-        self._low = AsyncComfyLow(
-            _resolve_base_url(), api_key, timeout=timeout, client_info=client_info
-        )
+        base_url = _resolve_base_url()
+        key = _resolve_api_key(api_key, base_url)
+        self._low = AsyncComfyLow(base_url, key, timeout=timeout, client_info=client_info)
         self.assets = AsyncAssetFactory(self._low)
         self.workflows = WorkflowFactory()
         self.jobs = AsyncJobFactory(self._low)
@@ -248,6 +310,13 @@ class AsyncComfy:
 
     async def __aexit__(self, *exc: object) -> None:
         await self.aclose()
+
+    def __repr__(self) -> str:
+        """Key-free, exactly as :meth:`Comfy.__repr__`."""
+        return (
+            f"{type(self).__name__}(base_url={self._low.base_url!r}, "
+            f"authenticated={self._low.authenticated})"
+        )
 
     async def _materialize(self, workflow: Workflow) -> dict[str, Any]:
         handles = _core.find_asset_handles(workflow.json)

--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -34,10 +34,23 @@ class ComfyError(Exception):
         self.details = details
 
 
+class MissingApiKey(ComfyError):
+    """No credential could be resolved for a surface that requires one.
+
+    Raised locally at client construction — before any request — when neither an
+    explicit ``api_key`` argument nor ``COMFY_API_KEY`` supplied a key and the
+    target is Comfy Cloud. Distinct from :class:`Unauthorized`, which is the
+    server rejecting a key that *was* sent. The message names the environment
+    variable, and never contains a key (there is none to contain).
+    """
+
+
 class Unauthorized(ComfyError):
     """The surface rejected the request for lack of a valid key.
 
     Comfy Cloud and serverless require a key; a self-hosted proxy needs none.
+    Its local counterpart is :class:`MissingApiKey` — no key at all, caught at
+    construction rather than on the wire.
     """
 
 

--- a/src/comfy_sdk/models.py
+++ b/src/comfy_sdk/models.py
@@ -53,7 +53,10 @@ class _ModelsBase:
         return self._low.timeout
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(base_url={self.base_url!r})"
+        # Redacted like the host client's repr: a base URL may carry proxy
+        # credentials in its userinfo, and this namespace lands in the same
+        # tracebacks and CI logs the client does.
+        return f"{type(self).__name__}(base_url={self._low.safe_base_url!r})"
 
 
 class Models(_ModelsBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from comfy_sdk import BASE_URL_ENV_VAR
+from comfy_sdk import API_KEY_ENV_VAR, BASE_URL_ENV_VAR
 
 
 @dataclass
@@ -481,6 +481,20 @@ def _no_ambient_base_url(request, monkeypatch):
     if "integration" in request.path.parts:
         return
     monkeypatch.delenv(BASE_URL_ENV_VAR, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_key(monkeypatch):
+    """Never let the developer's own ``COMFY_API_KEY`` reach a test client.
+
+    Autouse and unconditional: the SDK now falls back to that variable, so a key
+    exported in the shell (or on a CI runner running the live gateway e2e job)
+    would silently authenticate clients the suite builds deliberately *without*
+    one — turning the no-credentials-sent assertions green for the wrong reason.
+    The gateway e2e test reads the variable at import time and passes it
+    explicitly, so it is unaffected.
+    """
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
 
 
 @pytest.fixture

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -15,6 +15,11 @@ case below sets exactly the environment it names.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
 import httpx
 import pytest
 
@@ -34,6 +39,25 @@ LOCAL = "http://127.0.0.1:8189"
 
 # Both clients resolve credentials identically, so every case runs against both.
 CLIENTS = pytest.mark.parametrize("client_cls", [Comfy, AsyncComfy], ids=["sync", "async"])
+
+
+@contextmanager
+def constructed(client_cls: type, **kwargs: Any) -> Iterator[Any]:
+    """Construct a client and always release its transport.
+
+    Each client owns an httpx transport, so every one built here has to be
+    closed. Only ``AsyncComfy`` needs a loop to close, and hiding that in one
+    helper is what lets a case below stay a single parametrized test running
+    against both clients instead of a sync copy and an async copy.
+    """
+    client = client_cls(**kwargs)
+    try:
+        yield client
+    finally:
+        if isinstance(client, AsyncComfy):
+            asyncio.run(client.aclose())
+        else:
+            client.close()
 
 
 def auth_header(client: Comfy | AsyncComfy) -> str | None:
@@ -66,8 +90,8 @@ def test_key_resolution_order(monkeypatch, client_cls, explicit, env, expected) 
         with pytest.raises(MissingApiKey):
             client_cls(api_key=explicit)
         return
-    client = client_cls(api_key=explicit)
-    assert auth_header(client) == expected
+    with constructed(client_cls, api_key=explicit) as client:
+        assert auth_header(client) == expected
 
 
 # --- the failure is local, clear, and named -------------------------------
@@ -121,30 +145,30 @@ def test_missing_key_is_a_comfy_error(client_cls) -> None:
 @CLIENTS
 def test_key_is_never_in_repr_or_str(client_cls) -> None:
     """The most common way a credential lands in a CI log."""
-    client = client_cls(api_key=EXPLICIT)
-    for rendered in (repr(client), str(client), repr(client._low), repr(client._low._p)):
-        assert EXPLICIT not in rendered
-    # ...and the repr still says something useful about the credential.
-    assert "authenticated=True" in repr(client)
-    assert client._low.authenticated is True
+    with constructed(client_cls, api_key=EXPLICIT) as client:
+        for rendered in (repr(client), str(client), repr(client._low), repr(client._low._p)):
+            assert EXPLICIT not in rendered
+        # ...and the repr still says something useful about the credential.
+        assert "authenticated=True" in repr(client)
+        assert client._low.authenticated is True
 
 
 @CLIENTS
 def test_key_from_the_environment_is_never_in_repr_or_str(monkeypatch, client_cls) -> None:
     """Same guarantee whichever source the key came from."""
     monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
-    client = client_cls()
-    assert FROM_ENV not in repr(client)
-    assert FROM_ENV not in str(client)
-    assert FROM_ENV not in repr(client._low._p)
+    with constructed(client_cls) as client:
+        assert FROM_ENV not in repr(client)
+        assert FROM_ENV not in str(client)
+        assert FROM_ENV not in repr(client._low._p)
 
 
 @CLIENTS
 def test_keyless_client_reports_unauthenticated(monkeypatch, client_cls) -> None:
     monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
-    client = client_cls()
-    assert "authenticated=False" in repr(client)
-    assert client._low.authenticated is False
+    with constructed(client_cls) as client:
+        assert "authenticated=False" in repr(client)
+        assert client._low.authenticated is False
 
 
 def test_key_is_never_in_a_rejected_request_error(server) -> None:
@@ -172,7 +196,8 @@ def test_key_is_never_in_a_rejected_request_error(server) -> None:
 def test_surrounding_whitespace_is_stripped(monkeypatch, client_cls, raw) -> None:
     """A key read out of a file keeps its trailing newline; it must not reach the header."""
     monkeypatch.setenv(API_KEY_ENV_VAR, raw)
-    assert auth_header(client_cls()) == f"Bearer {FROM_ENV}"
+    with constructed(client_cls) as client:
+        assert auth_header(client) == f"Bearer {FROM_ENV}"
 
 
 @CLIENTS
@@ -184,14 +209,16 @@ def test_blank_counts_as_unset_at_either_source(monkeypatch, client_cls, blank) 
         client_cls()
     # A blank explicit argument falls through to a usable environment key.
     monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
-    assert auth_header(client_cls(api_key=blank)) == f"Bearer {FROM_ENV}"
+    with constructed(client_cls, api_key=blank) as client:
+        assert auth_header(client) == f"Bearer {FROM_ENV}"
 
 
 @CLIENTS
 def test_self_hosted_deployment_still_needs_no_key(monkeypatch, client_cls) -> None:
     """The documented keyless surface is untouched: no error, and no credential."""
     monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
-    assert auth_header(client_cls()) is None
+    with constructed(client_cls) as client:
+        assert auth_header(client) is None
 
 
 @CLIENTS
@@ -199,7 +226,8 @@ def test_environment_key_is_used_against_a_named_deployment(monkeypatch, client_
     """The fallback is not Cloud-only — a serverless target picks it up too."""
     monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
     monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
-    assert auth_header(client_cls()) == f"Bearer {FROM_ENV}"
+    with constructed(client_cls) as client:
+        assert auth_header(client) == f"Bearer {FROM_ENV}"
 
 
 @CLIENTS
@@ -208,6 +236,92 @@ def test_cloud_named_explicitly_still_requires_a_key(monkeypatch, client_cls) ->
     monkeypatch.setenv(BASE_URL_ENV_VAR, COMFY_CLOUD_BASE_URL + "/")
     with pytest.raises(MissingApiKey):
         client_cls()
+
+
+@CLIENTS
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        pytest.param(COMFY_CLOUD_BASE_URL + ":443", id="explicit-default-port"),
+        pytest.param(COMFY_CLOUD_BASE_URL + ":443/", id="explicit-default-port-slash"),
+        pytest.param("https://CLOUD.Comfy.ORG", id="mixed-case-host"),
+    ],
+)
+def test_cloud_by_another_spelling_still_requires_a_key(monkeypatch, client_cls, spelling) -> None:
+    """The rule follows the deployment, not the string that happens to name it.
+
+    ``https://cloud.comfy.org:443`` is Comfy Cloud with its default port
+    written out. Matching Cloud by string alone would miss it, hand back a
+    keyless client, and turn this module's local error into a server 401 on the
+    first request — exactly the failure the local check exists to prevent.
+    """
+    monkeypatch.setenv(BASE_URL_ENV_VAR, spelling)
+    with pytest.raises(MissingApiKey):
+        client_cls()
+
+
+@CLIENTS
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        pytest.param("https://cloud.comfy.org/self-hosted", id="path-mounted"),
+        pytest.param("https://cloud.comfy.org:8443", id="other-port"),
+    ],
+)
+def test_a_different_deployment_on_the_same_host_stays_keyless(
+    monkeypatch, client_cls, spelling
+) -> None:
+    """Recognizing more spellings of Cloud must not swallow the neighbours.
+
+    A deployment mounted under a path on the same host — or reached on another
+    port — is a different target, and the documented keyless carve-out still
+    applies to it. This is the other half of the test above: the comparison has
+    to be wide enough to catch Cloud and narrow enough to leave these alone.
+    """
+    monkeypatch.setenv(BASE_URL_ENV_VAR, spelling)
+    with constructed(client_cls) as client:
+        assert auth_header(client) is None
+
+
+# --- a credential embedded in the base URL never leaks either --------------
+
+PROXY_SECRET = "comfyui-proxy-secret"
+PROXY_BASE_URL = f"https://proxy-user:{PROXY_SECRET}@proxy.example"
+
+
+@CLIENTS
+def test_base_url_userinfo_is_redacted_in_every_repr(monkeypatch, client_cls) -> None:
+    """The other credential a client can hold: one embedded in its base URL.
+
+    ``COMFY_BASE_URL=https://user:token@proxy.example`` is a valid way to reach
+    a deployment behind an authenticating proxy, and a repr that prints it
+    verbatim leaks it to the same CI logs and tracebacks the API key is kept
+    out of. Only what is *rendered* is redacted — the transport still resolves
+    requests against the URL it was given, so the proxy credential keeps
+    working.
+    """
+    monkeypatch.setenv(BASE_URL_ENV_VAR, PROXY_BASE_URL)
+    with constructed(client_cls) as client:
+        for rendered in (
+            repr(client),
+            str(client),
+            repr(client._low),
+            repr(client._low._p),
+            repr(client.models),
+        ):
+            assert PROXY_SECRET not in rendered
+            assert "proxy-user" not in rendered
+            assert "***@proxy.example" in rendered
+        assert client._low.base_url == PROXY_BASE_URL
+
+
+@CLIENTS
+def test_a_base_url_without_userinfo_is_rendered_unchanged(monkeypatch, client_cls) -> None:
+    """Redaction stays invisible in the ordinary case — the target reads plainly."""
+    monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
+    with constructed(client_cls) as client:
+        assert f"base_url={LOCAL!r}" in repr(client)
+        assert f"base_url={LOCAL!r}" in repr(client._low)
 
 
 def test_environment_key_reaches_the_server(server, monkeypatch) -> None:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,220 @@
+"""Credential resolution: explicit argument, then ``COMFY_API_KEY``, then a clear error.
+
+Locks in the order the clients document, the *locality* of the failure (no
+network call is attempted when nothing resolves), and the one property that is
+easiest to lose by accident: the key never appears in a ``repr``, a ``str``, or
+an exception message. That last one is the most common way a credential ends up
+in someone's CI log, so it is asserted rather than assumed.
+
+The self-hosted case stays keyless on purpose — a deployment named by
+``COMFY_BASE_URL`` may have no auth at all, so an unresolved key is only an
+error against Comfy Cloud (see ``test_auth_headers.py`` for the wire proof that
+nothing is sent). ``conftest`` strips an ambient ``COMFY_API_KEY``, so every
+case below sets exactly the environment it names.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from comfy_sdk import (
+    API_KEY_ENV_VAR,
+    BASE_URL_ENV_VAR,
+    COMFY_CLOUD_BASE_URL,
+    AsyncComfy,
+    Comfy,
+    ComfyError,
+    MissingApiKey,
+)
+
+EXPLICIT = "comfyui-explicit"
+FROM_ENV = "comfyui-from-env"
+LOCAL = "http://127.0.0.1:8189"
+
+# Both clients resolve credentials identically, so every case runs against both.
+CLIENTS = pytest.mark.parametrize("client_cls", [Comfy, AsyncComfy], ids=["sync", "async"])
+
+
+def auth_header(client: Comfy | AsyncComfy) -> str | None:
+    """The ``Authorization`` header this client would put on a same-origin request."""
+    prepared = client._low._p
+    return prepared.headers(prepared.url("/jobs")).get("Authorization")
+
+
+def test_env_var_name() -> None:
+    assert API_KEY_ENV_VAR == "COMFY_API_KEY"
+
+
+# --- the table: explicit / env / neither / both, against the Cloud default ---
+
+
+@CLIENTS
+@pytest.mark.parametrize(
+    "explicit, env, expected",
+    [
+        pytest.param(EXPLICIT, None, f"Bearer {EXPLICIT}", id="explicit-only"),
+        pytest.param(None, FROM_ENV, f"Bearer {FROM_ENV}", id="env-only"),
+        pytest.param(None, None, None, id="neither-raises"),
+        pytest.param(EXPLICIT, FROM_ENV, f"Bearer {EXPLICIT}", id="both-explicit-wins"),
+    ],
+)
+def test_key_resolution_order(monkeypatch, client_cls, explicit, env, expected) -> None:
+    if env is not None:
+        monkeypatch.setenv(API_KEY_ENV_VAR, env)
+    if expected is None:
+        with pytest.raises(MissingApiKey):
+            client_cls(api_key=explicit)
+        return
+    client = client_cls(api_key=explicit)
+    assert auth_header(client) == expected
+
+
+# --- the failure is local, clear, and named -------------------------------
+
+
+@CLIENTS
+def test_missing_key_names_the_environment_variable(client_cls) -> None:
+    """The message alone has to be enough to fix it."""
+    with pytest.raises(MissingApiKey) as exc:
+        client_cls()
+    assert API_KEY_ENV_VAR in str(exc.value)
+    assert "api_key" in str(exc.value)
+    # The escape hatch for a deployment that needs no key is named too.
+    assert BASE_URL_ENV_VAR in str(exc.value)
+
+
+@CLIENTS
+def test_missing_key_raises_before_any_network_call(monkeypatch, client_cls) -> None:
+    """Construction must fail locally — not as a 401 the server has to tell us about.
+
+    Both httpx send paths are booby-trapped, so any request the client tried to
+    make would surface as the ``AssertionError`` below instead of the expected
+    ``MissingApiKey``. Failing early is the whole point of the check: a missing
+    credential reported as a server 401 sends the caller looking at their key's
+    validity rather than its absence, and costs a round trip to say so.
+    """
+
+    def _no_network(*args: object, **kw: object) -> None:
+        raise AssertionError("the client attempted a request before resolving credentials")
+
+    monkeypatch.setattr(httpx.Client, "send", _no_network)
+    monkeypatch.setattr(httpx.AsyncClient, "send", _no_network)
+    with pytest.raises(MissingApiKey):
+        client_cls()
+
+
+@CLIENTS
+def test_missing_key_is_a_comfy_error(client_cls) -> None:
+    """Catchable by an integrator who catches the SDK base error, with a code."""
+    with pytest.raises(ComfyError) as exc:
+        client_cls()
+    assert isinstance(exc.value, MissingApiKey)
+    assert exc.value.code == "missing_api_key"
+    # It never reached a server, so there is no HTTP status to report.
+    assert exc.value.http_status is None
+
+
+# --- the key never leaks ---------------------------------------------------
+
+
+@CLIENTS
+def test_key_is_never_in_repr_or_str(client_cls) -> None:
+    """The most common way a credential lands in a CI log."""
+    client = client_cls(api_key=EXPLICIT)
+    for rendered in (repr(client), str(client), repr(client._low), repr(client._low._p)):
+        assert EXPLICIT not in rendered
+    # ...and the repr still says something useful about the credential.
+    assert "authenticated=True" in repr(client)
+    assert client._low.authenticated is True
+
+
+@CLIENTS
+def test_key_from_the_environment_is_never_in_repr_or_str(monkeypatch, client_cls) -> None:
+    """Same guarantee whichever source the key came from."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
+    client = client_cls()
+    assert FROM_ENV not in repr(client)
+    assert FROM_ENV not in str(client)
+    assert FROM_ENV not in repr(client._low._p)
+
+
+@CLIENTS
+def test_keyless_client_reports_unauthenticated(monkeypatch, client_cls) -> None:
+    monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
+    client = client_cls()
+    assert "authenticated=False" in repr(client)
+    assert client._low.authenticated is False
+
+
+def test_key_is_never_in_a_rejected_request_error(server) -> None:
+    """The path where an exception is raised *while the client holds* a key.
+
+    ``MissingApiKey`` cannot leak one (it is raised because there is none), so
+    the guard that matters is a server rejection — the moment an SDK error is
+    most tempting to make "helpful" by quoting the credential that failed. The
+    stub answers 401 to a request that did carry the bearer token.
+    """
+    server.state.job_error = (401, "unauthorized")
+    with Comfy(api_key=EXPLICIT) as client:
+        with pytest.raises(ComfyError) as exc:
+            client.submit(client.workflows.from_json({"3": {"class_type": "K", "inputs": {}}}))
+    assert server.state.last_auth_header == f"Bearer {EXPLICIT}"
+    assert EXPLICIT not in str(exc.value)
+    assert EXPLICIT not in repr(exc.value)
+
+
+# --- normalization + the self-hosted carve-out ------------------------------
+
+
+@CLIENTS
+@pytest.mark.parametrize("raw", [f"  {FROM_ENV}  ", f"{FROM_ENV}\n"], ids=["spaces", "newline"])
+def test_surrounding_whitespace_is_stripped(monkeypatch, client_cls, raw) -> None:
+    """A key read out of a file keeps its trailing newline; it must not reach the header."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, raw)
+    assert auth_header(client_cls()) == f"Bearer {FROM_ENV}"
+
+
+@CLIENTS
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_counts_as_unset_at_either_source(monkeypatch, client_cls, blank) -> None:
+    """``COMFY_API_KEY=`` in a shell profile is 'no key', not a key of no characters."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, blank)
+    with pytest.raises(MissingApiKey):
+        client_cls()
+    # A blank explicit argument falls through to a usable environment key.
+    monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
+    assert auth_header(client_cls(api_key=blank)) == f"Bearer {FROM_ENV}"
+
+
+@CLIENTS
+def test_self_hosted_deployment_still_needs_no_key(monkeypatch, client_cls) -> None:
+    """The documented keyless surface is untouched: no error, and no credential."""
+    monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
+    assert auth_header(client_cls()) is None
+
+
+@CLIENTS
+def test_environment_key_is_used_against_a_named_deployment(monkeypatch, client_cls) -> None:
+    """The fallback is not Cloud-only — a serverless target picks it up too."""
+    monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
+    monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
+    assert auth_header(client_cls()) == f"Bearer {FROM_ENV}"
+
+
+@CLIENTS
+def test_cloud_named_explicitly_still_requires_a_key(monkeypatch, client_cls) -> None:
+    """Setting ``COMFY_BASE_URL`` to Cloud is the same surface, so the same rule."""
+    monkeypatch.setenv(BASE_URL_ENV_VAR, COMFY_CLOUD_BASE_URL + "/")
+    with pytest.raises(MissingApiKey):
+        client_cls()
+
+
+def test_environment_key_reaches_the_server(server, monkeypatch) -> None:
+    """End-to-end: a key resolved from the environment is really sent on the wire."""
+    server.state.require_auth = True
+    monkeypatch.setenv(API_KEY_ENV_VAR, FROM_ENV)
+    with Comfy() as client:
+        job = client.submit(client.workflows.from_json({"3": {"class_type": "K", "inputs": {}}}))
+        job.refresh()
+    assert server.state.last_auth_header == f"Bearer {FROM_ENV}"

--- a/tests/test_base_url_env.py
+++ b/tests/test_base_url_env.py
@@ -35,7 +35,9 @@ def test_env_var_selects_the_deployment(monkeypatch) -> None:
 
 def test_env_var_is_read_per_construction(monkeypatch) -> None:
     """A later client picks up a changed target — the value is not import-time."""
-    with Comfy() as first:
+    # The Cloud default requires a key, so the first client is built with one;
+    # the second targets a keyless self-hosted deployment. See test_api_key.py.
+    with Comfy(api_key="comfyui-test") as first:
         assert job_url(first) == CLOUD_JOB_URL
     monkeypatch.setenv(BASE_URL_ENV_VAR, LOCAL)
     with Comfy() as second:
@@ -45,7 +47,7 @@ def test_env_var_is_read_per_construction(monkeypatch) -> None:
 @pytest.mark.parametrize("blank", ["", "   "])
 def test_blank_env_var_means_comfy_cloud(monkeypatch, blank: str) -> None:
     monkeypatch.setenv(BASE_URL_ENV_VAR, blank)
-    with Comfy() as client:
+    with Comfy(api_key="comfyui-test") as client:
         assert job_url(client) == CLOUD_JOB_URL
 
 

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -36,6 +36,8 @@ def test_client_info_appends_app_token(server) -> None:
 
 def test_client_info_rejects_crlf() -> None:
     # A CR/LF in the caller token must never reach the header (no injection).
+    # The Cloud default requires a key, so supply one: the point here is that
+    # `client_info` is rejected, not which construction error arrives first.
     for bad in ("evil\r\nX-Injected: 1", "line\nbreak", "carriage\rreturn"):
         with pytest.raises(ValueError):
-            Comfy(client_info=bad)
+            Comfy(api_key="comfyui-test", client_info=bad)


### PR DESCRIPTION
## ELI-5

If you forget your API key, the SDK now tells you so the moment you build a client — and tells you which environment variable to set — instead of letting the server say `401` a round trip later. It also looks in `COMFY_API_KEY` for you, so you don't have to paste the key into your code at all.

## What changed

A client resolves its credential once, at construction, in a fixed order:

1. the explicit `api_key=` argument — it always wins;
2. `COMFY_API_KEY` from the environment, when no argument was passed;
3. neither → `MissingApiKey`, raised locally, naming the environment variable.

Both sources are trimmed and a blank value counts as unset, so `COMFY_API_KEY=` in a shell profile and a key read from a file with a trailing newline both do the obvious thing. Both are re-read on every construction, matching how `COMFY_BASE_URL` already behaves.

`Comfy`/`AsyncComfy` also gain an explicit `repr()` — base URL plus `authenticated=True|False`, never the key — backed by a new `ComfyLow.authenticated` property. `comfy_low` is otherwise unchanged: it takes the key it is handed and reads no environment, because resolution is a `comfy_sdk` concern.

## The one judgment call: step 3 applies to Comfy Cloud only

The repo already documents, and tests, a surface that legitimately has **no** credential — "Self-hosted ComfyUI (behind the API proxy) | Omit — no key is sent, even implicitly" in the README, locked in by `tests/test_auth_headers.py`. An unconditional "no key → raise" would delete that capability, so the error fires only when the resolved base URL is Comfy Cloud (the default). Point `COMFY_BASE_URL` at anything else and an unresolved key means exactly what it has always meant: build the client, send no credentials. The error message names `COMFY_BASE_URL` for precisely that reason — it redirects you to the path that still works rather than dead-ending.

Consequence worth stating plainly: a **serverless** deployment does require a key but is also selected by `COMFY_BASE_URL`, so a keyless serverless client is still a server `401`, as today. The SDK cannot tell a serverless URL from a self-hosted one, and guessing wrong would deny a working configuration.

Second consequence: on the Cloud default, key resolution now runs *before* the transport validates `client_info`, so a client built with both a bad `client_info` and no key sees `MissingApiKey` first. Base-URL validation still runs first of all, since it decides whether a key is required at all.

## Verification of the capability this denies

The new code path denies one thing: constructing a working keyless client against Comfy Cloud. Attempted it directly, read-only, against the live surface before shipping the dead-end:

```
GET https://cloud.comfy.org/api/v2/jobs/00000000-0000-0000-0000-000000000000   (no Authorization)
  -> 401 {"error":{"code":"unauthorized","message":"Missing or invalid API key. Send 'Authorization: Bearer <your comfyui- key>'."}}
HEAD https://cloud.comfy.org/api/v2/assets/by-hash/blake3:<64-hex>             (no Authorization)
  -> 401
```

Both a read and a probe are rejected unauthenticated, so a keyless Cloud client could only ever have produced that `401` — the change replaces a guaranteed server rejection with a local one, and does not remove any reachable capability. The surviving keyless path is exercised live in the opposite direction: `test_auth_headers.py::test_no_api_key_sends_no_authorization_header_at_all` builds a keyless client against the stub server over real HTTP and asserts no `Authorization` header arrives at all — still green, unmodified.

## Leak sweep — including the part this diff does not touch

Swept every public-surface object reachable from a client built with a sentinel key and rendered each through `repr()`, `str()` and `format()`: **13 objects, 0 render the key.** 5 of those are on the credential-bearing chain this diff touched (`Comfy`, `AsyncComfy`, `ComfyLow`, `AsyncComfyLow`, `_Prepared`); the other **8 were not touched** (`AssetFactory`, `AsyncAssetFactory`, `JobFactory`, `AsyncJobFactory`, `Models`, `AsyncModels`, `Workflow`, `WorkflowFactory`) and were pointed at by the same sweep, which is the half that would otherwise have gone unchecked. The remaining handle reprs (`Job`, `AsyncJob`, `Asset`, `Output`, `AsyncOutput`) need a live server to construct, so they were read instead: each renders only ids/status/paths, never its transport. `grep -rn 'import logging\|print('` over `src/` returns nothing — the SDK does no logging at all, which is how "never logged" holds.

## Tests

`tests/test_api_key.py` is new, and every case runs against both `Comfy` and `AsyncComfy`:

- **the table** — explicit-only, env-only, neither (raises), both-present (explicit wins);
- **locality** — both httpx `send` paths are monkeypatched to raise, so any request attempted during construction surfaces as an `AssertionError` instead of the expected `MissingApiKey`;
- **the message** names `COMFY_API_KEY`, the `api_key=` argument, and `COMFY_BASE_URL`; it is a `ComfyError` with `code="missing_api_key"` and `http_status is None`;
- **no leak** — the key is absent from `repr`/`str` of the client, its transport and `_Prepared`, whichever source it came from; and a keyed client that gets a `401` back raises an error carrying no key;
- **normalization** — whitespace stripped, blank counts as unset at either source;
- **the carve-out** — a `COMFY_BASE_URL` deployment still builds keyless and sends nothing, still picks up `COMFY_API_KEY` when set, and Cloud named explicitly (trailing slash included) still requires a key;
- **end to end** — a key resolved from the environment really arrives at the stub server as `Bearer …`.

`tests/conftest.py` gains an autouse fixture stripping an ambient `COMFY_API_KEY`, mirroring the existing `COMFY_BASE_URL` one: now that the SDK reads that variable, a key exported in a developer's shell would silently authenticate the clients the suite builds deliberately without one, turning the no-credentials-sent assertions green for the wrong reason. Three pre-existing tests that built a keyless client against the Cloud default (two in `test_base_url_env.py`, one in `test_user_agent.py`) now pass a key — none of them was about credentials.

## Acceptance criteria

| Criterion | |
|---|---|
| Explicit argument beats the environment | ✅ |
| `COMFY_API_KEY` read when no explicit key | ✅ |
| Clear, named error raised locally, no network call | ✅ **against Comfy Cloud** — see the judgment call above |
| Error names the environment variable | ✅ |
| Key never logged / in `repr`/`str` / in an exception message, with a test | ✅ |
| Resolution order documented in the package reference | ✅ README "Where the key comes from", module docstrings, CHANGELOG |
| Table-driven test over three cases + both-present | ✅ |

## Unexercised artifacts

The source ticket links two internal planning documents (a PRD section and a gameplan row) that specify the resolution order. Both are on an internal collaboration tool this worker cannot reach, so the order implemented here comes from the ticket's own acceptance criteria, not from reading those documents — if they say something more specific about the self-hosted carve-out, that is the thing to check at review. The ticket's parent epic was likewise named but not fetched. No attachment was reachable and no comment on the ticket carried substantive detail.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `ruff check .` clean; `ruff format --check .` 45 files already formatted; `mypy src` no issues in 17 files; `pytest -q` 217 passed / 4 skipped (up from 213 passed pre-change); `scripts/check_drift.py` models in sync; `scripts/check_public_repo_hygiene.py` no internal-only references. Live read-only falsification against `cloud.comfy.org` as quoted above.
- **Deviations:** the missing-credential error is raised for the Comfy Cloud target only, not unconditionally — an unconditional raise would remove the repo's documented and tested keyless self-hosted surface. Rationale and consequences are in "The one judgment call" above. No other criterion was skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API key resolution from an explicit value or the `COMFY_API_KEY` environment variable.
  - Added public `MissingApiKey` and `API_KEY_ENV_VAR` exports.
  - Custom deployments can operate without credentials; Comfy Cloud requires an API key.
  - Added authentication status indicators and secure client representations that never expose credentials.

- **Documentation**
  - Documented credential precedence, validation, deployment behavior, and secure credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->