### PR TITLE
feat: add the typed router exception hierarchy for the models surface

### DIFF
--- a/src/comfy_sdk/router_exceptions.py
+++ b/src/comfy_sdk/router_exceptions.py
@@ -1,0 +1,410 @@
+"""Typed exceptions for the Comfy Router model-run surface (``client.models``).
+
+One class per ``error_type`` in the router's closed error set, so a caller
+branches on a class rather than on a string::
+
+    from comfy_sdk.router_exceptions import ContentPolicyViolation, RouterError
+
+    try:
+        ...                                    # a client.models call
+    except ContentPolicyViolation as exc:
+        print(exc.detail, exc.request_id)      # deterministic — do not retry
+    except RouterError as exc:
+        report(exc.error_type, exc.request_id)
+
+Three properties of this module are contract, not taste:
+
+**The class name is the PascalCase of the wire value, always.** ``invalid_input``
+is :class:`InvalidInput`, ``content_policy_violation`` is
+:class:`ContentPolicyViolation`. That mechanical rule is what keeps this list and
+the TypeScript SDK's identical without either side maintaining a second table --
+an example ported between the two languages finds the same names.
+``test_router_exceptions.py`` asserts the rule over every class, so a
+hand-picked name cannot creep in.
+
+**Every class derives from :class:`RouterError`.** A caller who wants the broad
+catch writes ``except RouterError``; one who wants a single failure mode names
+it. ``RouterError`` in turn derives from :class:`~comfy_sdk.exceptions.ComfyError`,
+so ``except ComfyError`` still covers the whole SDK.
+
+**An unrecognised ``error_type`` raises the base class rather than failing.**
+The error set grows on the server's release cycle while an SDK is pinned by its
+users, so a bucket this version has never heard of must still arrive as a
+catchable exception carrying its raw ``error_type`` -- treat one like
+``internal_error``. A client that rejected the unknown value would fail hardest
+exactly when something has already gone wrong.
+
+Three of these names -- ``Unauthorized``, ``Forbidden``, ``InsufficientCredits``
+-- already exist in :mod:`comfy_sdk.exceptions` for the workflow surface, where
+they mean the same thing about a different API. They are deliberately *not*
+merged and this module is deliberately *not* re-exported from the package root:
+one name cannot be two classes, and silently making ``comfy_sdk.Unauthorized``
+mean the router one would change what an existing ``except`` clause catches.
+Import the router ones from this module, or catch
+:class:`~comfy_sdk.exceptions.ComfyError` to cover both surfaces at once.
+
+The coarse bucket is not the whole story. A per-field model-validation failure
+carries a ``detail`` *array* whose entries keep the specific, provider-level
+reason; those arrive as :class:`ValidationErrorDetail` on ``.errors``, with
+``loc``/``msg``/``type``/``ctx`` readable as data. The exception message
+summarises them for a human, but the branch a caller writes reads the entries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .exceptions import ComfyError
+
+#: Response header carrying the coarse failure bucket. Set on every router error
+#: response, and on a per-field validation failure it is the only place the
+#: bucket appears -- that body has no ``error_type`` field of its own.
+ERROR_TYPE_HEADER = "X-Comfy-Error-Type"
+
+#: Response header carrying the server-minted id for the call, present on every
+#: response. It is the id a user quotes in a support request, so it is attached
+#: to every exception this module raises.
+REQUEST_ID_HEADER = "X-Comfy-Request-Id"
+
+
+@dataclass(frozen=True)
+class ValidationErrorDetail:
+    """One per-field model-validation failure.
+
+    ``type`` is the specific, provider-level reason (``value_error``,
+    ``missing``, ``image_too_small``, ``file_too_large``, ...) and is where the
+    granularity the coarse ``error_type`` bucket cannot express survives. It is
+    an open string: the provider vocabulary grows on the provider's release
+    cycle, not the SDK's, so an unmodelled value must reach the caller rather
+    than fail decoding.
+    """
+
+    #: Path to the offending field, outermost segment first --
+    #: ``("body", "image_url")``, or ``("body", "images", 0)`` where an integer
+    #: indexes into an array.
+    loc: tuple[str | int, ...] = ()
+    #: Human-readable description of this single failure.
+    msg: str = ""
+    #: Specific, machine-readable reason, passed through from the provider.
+    type: str = ""
+    #: The violated bound, when the reason carries one -- ``{"limit_value": 8}``
+    #: alongside ``greater_than``, ``{"min_width": 512}`` alongside
+    #: ``image_too_small``. Deliberately an open mapping: narrowing it to a fixed
+    #: field list is how a ported integration silently loses the branch that read
+    #: the bound. ``None`` when the reason carries no bound.
+    ctx: Mapping[str, Any] | None = None
+    #: The offending input value echoed back, so a caller can see what was
+    #: rejected without re-deriving it from ``loc``. Any JSON type, and ``None``
+    #: both when the value was null and when it was not echoed back at all.
+    input: Any = None
+
+    @property
+    def location(self) -> str:
+        """``loc`` as a dotted path -- ``body.images.0`` -- for display."""
+        return ".".join(str(part) for part in self.loc)
+
+
+class RouterError(ComfyError):
+    """Base for every Comfy Router failure, and what an unknown bucket raises.
+
+    ``error_type`` is the wire value; on this base class it is whatever the
+    server sent, including a value this SDK version does not know.
+    """
+
+    #: The wire ``error_type`` this class maps to. Empty on the base, which is
+    #: reached only by an unrecognised bucket (the instance sets it there).
+    error_type: str = ""
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        error_type: str | None = None,
+        http_status: int | None = None,
+        request_id: str | None = None,
+        errors: Sequence[ValidationErrorDetail] = (),
+    ) -> None:
+        resolved = error_type if error_type is not None else self.error_type
+        super().__init__(detail, code=resolved or None, http_status=http_status)
+        if error_type is not None:
+            self.error_type = error_type
+        #: Human-readable description of the failure, safe to show a user. Not
+        #: machine-parsed -- branch on the exception class instead.
+        self.detail = detail
+        #: Server-minted id for the call, from ``X-Comfy-Request-Id``. ``None``
+        #: only when the response carried no such header.
+        self.request_id = request_id
+        #: Per-field validation failures, populated whenever the response
+        #: carried the ``detail`` *array* -- see :class:`ValidationErrorDetail`.
+        #: Empty for every failure that names no field. It lives on the base
+        #: rather than on one subclass because the bucket a per-field failure
+        #: carries is read off the header, so the entries have to survive
+        #: whichever bucket that turns out to be.
+        self.errors: tuple[ValidationErrorDetail, ...] = tuple(errors)
+
+
+# -- the six request-level buckets -------------------------------------------
+
+
+class InvalidInput(RouterError):
+    """The request was rejected as invalid for this model."""
+
+    error_type = "invalid_input"
+
+
+class ContentPolicyViolation(RouterError):
+    """The model's content policy refused the request.
+
+    Deterministic: the same input will be refused again, so this is never a
+    retry candidate. It is deliberately not a :class:`ProviderError` -- the two
+    differ in whether a retry can ever succeed.
+    """
+
+    error_type = "content_policy_violation"
+
+
+class ProviderError(RouterError):
+    """The upstream model provider returned an error."""
+
+    error_type = "provider_error"
+
+
+class ProviderTimeout(RouterError):
+    """The upstream model provider did not respond in time.
+
+    An upstream running out of time, not our own deadline -- the two are
+    separate buckets because they are separate causes.
+    """
+
+    error_type = "provider_timeout"
+
+
+class InsufficientCredits(RouterError):
+    """The account does not have enough credits to run this model."""
+
+    error_type = "insufficient_credits"
+
+
+class ModelNotFound(RouterError):
+    """No such model. An unknown provider lands here too: both are "that id
+    names nothing"."""
+
+    error_type = "model_not_found"
+
+
+# -- the five transport-level buckets ----------------------------------------
+
+
+class Unauthorized(RouterError):
+    """Authentication is required, or the key presented was not accepted."""
+
+    error_type = "unauthorized"
+
+
+class Forbidden(RouterError):
+    """The caller is authenticated but has no access to this model."""
+
+    error_type = "forbidden"
+
+
+class ConcurrencyLimitExceeded(RouterError):
+    """Too many concurrent requests."""
+
+    error_type = "concurrency_limit_exceeded"
+
+
+class ClientDisconnected(RouterError):
+    """The client closed the connection before the request completed."""
+
+    error_type = "client_disconnected"
+
+
+class InternalError(RouterError):
+    """An internal error occurred."""
+
+    error_type = "internal_error"
+
+
+#: Every class in the closed set, in the order the error set declares it: the
+#: six request-level buckets, then the five transport-level ones.
+ROUTER_EXCEPTIONS: tuple[type[RouterError], ...] = (
+    InvalidInput,
+    ContentPolicyViolation,
+    ProviderError,
+    ProviderTimeout,
+    InsufficientCredits,
+    ModelNotFound,
+    Unauthorized,
+    Forbidden,
+    ConcurrencyLimitExceeded,
+    ClientDisconnected,
+    InternalError,
+)
+
+_BY_ERROR_TYPE: dict[str, type[RouterError]] = {cls.error_type: cls for cls in ROUTER_EXCEPTIONS}
+
+#: The closed ``error_type`` set this SDK version knows, in declaration order.
+#: Anything outside it raises :class:`RouterError` itself.
+ROUTER_ERROR_TYPES: tuple[str, ...] = tuple(_BY_ERROR_TYPE)
+
+# Status -> bucket, used ONLY when a response carries no bucket at all: a proxy,
+# gateway or load balancer that rejects a call before it reaches the router
+# answers with a status and no `X-Comfy-Error-Type`, and `except Unauthorized`
+# should still fire for a rejected key.
+#
+# Only statuses the error contract assigns to exactly ONE bucket appear here.
+# `400` is deliberately absent because it carries either `invalid_input` or
+# `content_policy_violation`, and those differ in whether a retry can ever
+# succeed -- guessing between them would tell a caller to retry a deterministic
+# refusal. `422` is absent for the same reason: the contract pins no bucket to
+# it. Both fall through to `RouterError`, which is the honest answer.
+_ERROR_TYPE_BY_STATUS: dict[int, str] = {
+    401: "unauthorized",
+    402: "insufficient_credits",
+    403: "forbidden",
+    404: "model_not_found",
+    429: "concurrency_limit_exceeded",
+    499: "client_disconnected",
+    502: "provider_error",
+    504: "provider_timeout",
+}
+
+
+def exception_for(error_type: str | None) -> type[RouterError]:
+    """The exception class for a wire ``error_type``.
+
+    Returns :class:`RouterError` for a value this SDK version does not know,
+    which is the forward-compatible answer: the caller still catches it and can
+    read the raw value off ``.error_type``.
+    """
+    if error_type is None:
+        return RouterError
+    return _BY_ERROR_TYPE.get(error_type, RouterError)
+
+
+def error_from_response(
+    http_status: int,
+    headers: Mapping[str, str] | None = None,
+    body: Any = None,
+) -> RouterError:
+    """Build the typed exception for a router error response.
+
+    ``body`` is the decoded JSON body, or ``None`` when there wasn't one (an
+    HTML error page from an intermediary, an empty 502). The bucket is read from
+    ``X-Comfy-Error-Type`` first and from the body's ``error_type`` second,
+    because the per-field validation body carries no ``error_type`` of its own.
+
+    This never raises. A malformed or unrecognised body degrades to the most
+    specific exception the response still supports -- worst case a bare
+    :class:`RouterError` -- because a client that blew up decoding an error
+    response would replace a diagnosable failure with an undiagnosable one.
+    """
+    lowered = _lowercase_headers(headers)
+    request_id = _clean(lowered.get(REQUEST_ID_HEADER.lower()))
+    error_type = _clean(lowered.get(ERROR_TYPE_HEADER.lower()))
+
+    detail: str | None = None
+    errors: tuple[ValidationErrorDetail, ...] = ()
+    if isinstance(body, Mapping):
+        raw_detail = body.get("detail")
+        if isinstance(raw_detail, str):
+            detail = raw_detail or None
+        elif isinstance(raw_detail, Sequence) and not isinstance(raw_detail, (str, bytes)):
+            errors = tuple(
+                _detail_from(entry) for entry in raw_detail if isinstance(entry, Mapping)
+            )
+        if error_type is None:
+            error_type = _clean(body.get("error_type"))
+
+    if error_type is None:
+        error_type = _ERROR_TYPE_BY_STATUS.get(http_status)
+
+    if detail is None:
+        detail = _summarise(errors) or f"HTTP {http_status}"
+
+    return exception_for(error_type)(
+        detail,
+        error_type=error_type,
+        http_status=http_status,
+        request_id=request_id,
+        errors=errors,
+    )
+
+
+def _lowercase_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    """Header names are case-insensitive on the wire; normalise so a plain dict
+    works as well as an ``httpx.Headers``."""
+    if not headers:
+        return {}
+    return {str(name).lower(): value for name, value in headers.items()}
+
+
+def _clean(value: Any) -> str | None:
+    """A header or body field as a non-empty string, or ``None``."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _detail_from(entry: Mapping[str, Any]) -> ValidationErrorDetail:
+    """One ``detail[]`` entry, tolerating a missing or wrongly-typed field.
+
+    Every field is optional here even though the contract makes ``loc``, ``msg``
+    and ``type`` required: this runs while handling a failure, and dropping the
+    two fields that did arrive because a third was malformed helps nobody.
+    """
+    raw_loc = entry.get("loc")
+    loc: tuple[str | int, ...] = ()
+    if isinstance(raw_loc, Sequence) and not isinstance(raw_loc, (str, bytes)):
+        loc = tuple(part if isinstance(part, (str, int)) else str(part) for part in raw_loc)
+
+    msg, reason, ctx = entry.get("msg"), entry.get("type"), entry.get("ctx")
+    return ValidationErrorDetail(
+        loc=loc,
+        msg=msg if isinstance(msg, str) else "",
+        type=reason if isinstance(reason, str) else "",
+        ctx=ctx if isinstance(ctx, Mapping) else None,
+        input=entry.get("input"),
+    )
+
+
+def _summarise(errors: Sequence[ValidationErrorDetail]) -> str:
+    """A one-line message for a per-field failure.
+
+    This is *in addition to* ``.errors``, never instead of it -- the entries stay
+    readable as data, and a caller branching on a field reads them rather than
+    parsing this back apart.
+    """
+    parts: list[str] = []
+    for entry in errors:
+        if entry.location and entry.msg:
+            parts.append(f"{entry.location}: {entry.msg}")
+        elif entry.location or entry.msg:
+            parts.append(entry.location or entry.msg)
+    return "; ".join(parts)
+
+
+__all__ = [
+    "ERROR_TYPE_HEADER",
+    "REQUEST_ID_HEADER",
+    "ROUTER_ERROR_TYPES",
+    "ROUTER_EXCEPTIONS",
+    "ClientDisconnected",
+    "ConcurrencyLimitExceeded",
+    "ContentPolicyViolation",
+    "Forbidden",
+    "InsufficientCredits",
+    "InternalError",
+    "InvalidInput",
+    "ModelNotFound",
+    "ProviderError",
+    "ProviderTimeout",
+    "RouterError",
+    "Unauthorized",
+    "ValidationErrorDetail",
+    "error_from_response",
+    "exception_for",
+]

--- a/tests/test_router_exceptions.py
+++ b/tests/test_router_exceptions.py
@@ -1,0 +1,387 @@
+"""The router exception hierarchy, raised and caught from stubbed error responses.
+
+Each case builds the response the router would actually send -- status, headers,
+decoded JSON body -- hands it to ``error_from_response``, raises the result, and
+catches it by name. That is the contract a caller depends on, so it is the thing
+under test rather than the lookup table on its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from comfy_sdk.exceptions import ComfyError
+from comfy_sdk.router_exceptions import (
+    ERROR_TYPE_HEADER,
+    REQUEST_ID_HEADER,
+    ROUTER_ERROR_TYPES,
+    ROUTER_EXCEPTIONS,
+    ClientDisconnected,
+    ConcurrencyLimitExceeded,
+    ContentPolicyViolation,
+    Forbidden,
+    InsufficientCredits,
+    InternalError,
+    InvalidInput,
+    ModelNotFound,
+    ProviderError,
+    ProviderTimeout,
+    RouterError,
+    Unauthorized,
+    ValidationErrorDetail,
+    error_from_response,
+    exception_for,
+)
+
+REQUEST_ID = "6f1a1a6e-6a53-4a5f-9d3a-2b3b0a1f9c21"
+
+# (error_type, the status the router returns with it, the class it must raise).
+# The statuses are part of the case on purpose: they document the pairing a
+# retry policy keys on (502 provider_error vs 504 provider_timeout).
+CASES: list[tuple[str, int, type[RouterError]]] = [
+    ("invalid_input", 400, InvalidInput),
+    ("content_policy_violation", 400, ContentPolicyViolation),
+    ("provider_error", 502, ProviderError),
+    ("provider_timeout", 504, ProviderTimeout),
+    ("insufficient_credits", 402, InsufficientCredits),
+    ("model_not_found", 404, ModelNotFound),
+    ("unauthorized", 401, Unauthorized),
+    ("forbidden", 403, Forbidden),
+    ("concurrency_limit_exceeded", 429, ConcurrencyLimitExceeded),
+    ("client_disconnected", 499, ClientDisconnected),
+    ("internal_error", 500, InternalError),
+]
+
+# Deliberately not in the set this SDK version knows: later milestones add them,
+# and until then each must arrive as the base class rather than crash a client.
+DEFERRED_ERROR_TYPES = ["file_download_error", "cancelled", "queue_timeout"]
+
+
+def stub_error_response(
+    error_type: str | None,
+    status: int,
+    *,
+    detail: Any = "Something went wrong.",
+    request_id: str | None = REQUEST_ID,
+) -> tuple[int, dict[str, str], dict[str, Any]]:
+    """A router error response: the two headers plus the request-level body."""
+    headers = {}
+    if error_type is not None:
+        headers[ERROR_TYPE_HEADER] = error_type
+    if request_id is not None:
+        headers[REQUEST_ID_HEADER] = request_id
+
+    body: dict[str, Any] = {"detail": detail}
+    if error_type is not None:
+        body["error_type"] = error_type
+    return status, headers, body
+
+
+# -- one class per error_type, raised and caught -----------------------------
+
+
+@pytest.mark.parametrize(("error_type", "status", "expected"), CASES)
+def test_each_error_type_raises_and_catches_its_own_class(
+    error_type: str, status: int, expected: type[RouterError]
+) -> None:
+    status, headers, body = stub_error_response(error_type, status)
+
+    with pytest.raises(expected) as caught:
+        raise error_from_response(status, headers, body)
+
+    exc = caught.value
+    assert exc.error_type == error_type
+    assert exc.http_status == status
+    assert exc.detail == "Something went wrong."
+    assert str(exc) == "Something went wrong."
+
+
+@pytest.mark.parametrize(("error_type", "status", "expected"), CASES)
+def test_every_class_is_catchable_as_the_router_base(
+    error_type: str, status: int, expected: type[RouterError]
+) -> None:
+    status, headers, body = stub_error_response(error_type, status)
+
+    with pytest.raises(RouterError) as caught:
+        raise error_from_response(status, headers, body)
+
+    assert type(caught.value) is expected
+
+
+def test_the_router_base_is_a_comfy_error() -> None:
+    # A caller who wants everything the SDK can raise keeps one except clause.
+    assert issubclass(RouterError, ComfyError)
+
+
+def test_the_closed_set_is_exactly_the_declared_error_types() -> None:
+    assert list(ROUTER_ERROR_TYPES) == [error_type for error_type, _, _ in CASES]
+    assert len(ROUTER_EXCEPTIONS) == len(ROUTER_ERROR_TYPES)
+
+
+@pytest.mark.parametrize("error_type", DEFERRED_ERROR_TYPES)
+def test_deferred_error_types_are_not_in_the_closed_set(error_type: str) -> None:
+    # Adding one is a decision someone makes on purpose, not a constant that
+    # quietly widens a set two SDKs generate from.
+    assert error_type not in ROUTER_ERROR_TYPES
+
+
+def test_class_names_are_the_pascal_case_of_the_wire_value() -> None:
+    # The naming rule is what keeps this list and the TypeScript SDK's identical
+    # without either side maintaining a second table.
+    for cls in ROUTER_EXCEPTIONS:
+        expected = "".join(part.capitalize() for part in cls.error_type.split("_"))
+        assert cls.__name__ == expected
+
+
+# -- forward compatibility ---------------------------------------------------
+
+
+@pytest.mark.parametrize("error_type", [*DEFERRED_ERROR_TYPES, "something_invented_later"])
+def test_an_unrecognised_error_type_raises_the_base_class(error_type: str) -> None:
+    status, headers, body = stub_error_response(error_type, 500)
+
+    with pytest.raises(RouterError) as caught:
+        raise error_from_response(status, headers, body)
+
+    # Base class, not a crash, and the raw value survives for the caller to log.
+    assert type(caught.value) is RouterError
+    assert caught.value.error_type == error_type
+    assert caught.value.request_id == REQUEST_ID
+
+
+def test_exception_for_maps_known_and_unknown_values() -> None:
+    assert exception_for("content_policy_violation") is ContentPolicyViolation
+    assert exception_for("queue_timeout") is RouterError
+    assert exception_for(None) is RouterError
+
+
+# -- the request id is on every exception ------------------------------------
+
+
+@pytest.mark.parametrize(("error_type", "status", "expected"), CASES)
+def test_the_request_id_is_attached_to_every_exception(
+    error_type: str, status: int, expected: type[RouterError]
+) -> None:
+    status, headers, body = stub_error_response(error_type, status)
+    assert error_from_response(status, headers, body).request_id == REQUEST_ID
+
+
+def test_the_request_id_header_is_matched_case_insensitively() -> None:
+    # Header names are case-insensitive on the wire, and an httpx.Headers is not
+    # the only mapping this is handed.
+    exc = error_from_response(
+        403,
+        {"x-comfy-request-id": REQUEST_ID, "x-comfy-error-type": "forbidden"},
+        {"detail": "No access.", "error_type": "forbidden"},
+    )
+    assert isinstance(exc, Forbidden)
+    assert exc.request_id == REQUEST_ID
+
+
+def test_a_missing_request_id_is_none_rather_than_an_error() -> None:
+    status, headers, body = stub_error_response("forbidden", 403, request_id=None)
+    assert error_from_response(status, headers, body).request_id is None
+
+
+# -- the 422: structured detail[] entries ------------------------------------
+
+VALIDATION_BODY: dict[str, Any] = {
+    "detail": [
+        {
+            "loc": ["body", "image_url"],
+            "msg": "image is smaller than the model's minimum",
+            "type": "image_too_small",
+            "ctx": {"min_width": 512},
+            "input": "https://example.com/tiny.png",
+        },
+        {
+            "loc": ["body", "images", 0],
+            "msg": "field required",
+            "type": "missing",
+        },
+    ]
+}
+
+
+def test_validation_detail_entries_are_readable_as_data() -> None:
+    # The per-field branch a caller writes has to survive: loc, msg, type and
+    # ctx are attributes, not substrings of the message.
+    exc = error_from_response(
+        422,
+        {ERROR_TYPE_HEADER: "invalid_input", REQUEST_ID_HEADER: REQUEST_ID},
+        VALIDATION_BODY,
+    )
+
+    assert isinstance(exc, InvalidInput)
+    assert len(exc.errors) == 2
+
+    first, second = exc.errors
+    assert first == ValidationErrorDetail(
+        loc=("body", "image_url"),
+        msg="image is smaller than the model's minimum",
+        type="image_too_small",
+        ctx={"min_width": 512},
+        input="https://example.com/tiny.png",
+    )
+    assert first.ctx is not None and first.ctx["min_width"] == 512
+    assert first.location == "body.image_url"
+
+    assert second.loc == ("body", "images", 0)  # an integer index stays an int
+    assert second.type == "missing"
+    assert second.ctx is None and second.input is None
+    assert second.location == "body.images.0"
+
+
+def test_the_validation_message_summarises_without_replacing_the_entries() -> None:
+    exc = error_from_response(422, {ERROR_TYPE_HEADER: "invalid_input"}, VALIDATION_BODY)
+
+    assert str(exc) == (
+        "body.image_url: image is smaller than the model's minimum; body.images.0: field required"
+    )
+    assert [e.type for e in exc.errors] == ["image_too_small", "missing"]
+
+
+def test_the_422_bucket_is_read_off_the_header_the_body_does_not_carry_one() -> None:
+    # The per-field body has no error_type field at all, so the header is the
+    # only place the bucket appears.
+    assert "error_type" not in VALIDATION_BODY
+    exc = error_from_response(422, {ERROR_TYPE_HEADER: "invalid_input"}, VALIDATION_BODY)
+    assert type(exc) is InvalidInput
+
+
+def test_a_request_level_failure_carries_no_detail_entries() -> None:
+    status, headers, body = stub_error_response("forbidden", 403)
+    assert error_from_response(status, headers, body).errors == ()
+
+
+# -- where the bucket is read from -------------------------------------------
+
+
+def test_the_header_wins_over_the_body() -> None:
+    # One value is written to both by the server, so they cannot normally
+    # disagree; if they ever do, the header is the one the contract calls
+    # authoritative and the only one the 422 has.
+    exc = error_from_response(
+        400,
+        {ERROR_TYPE_HEADER: "content_policy_violation"},
+        {"detail": "Refused.", "error_type": "invalid_input"},
+    )
+    assert type(exc) is ContentPolicyViolation
+
+
+def test_the_body_is_used_when_the_header_is_absent() -> None:
+    exc = error_from_response(
+        402, {}, {"detail": "No credits.", "error_type": "insufficient_credits"}
+    )
+    assert type(exc) is InsufficientCredits
+    assert exc.detail == "No credits."
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (401, Unauthorized),
+        (402, InsufficientCredits),
+        (403, Forbidden),
+        (404, ModelNotFound),
+        (429, ConcurrencyLimitExceeded),
+        (499, ClientDisconnected),
+        (502, ProviderError),
+        (504, ProviderTimeout),
+    ],
+)
+def test_a_response_with_no_bucket_falls_back_to_the_status(
+    status: int, expected: type[RouterError]
+) -> None:
+    # A proxy or gateway that rejects the call before it reaches the router
+    # answers with a status and none of the router's headers; `except
+    # Unauthorized` should still fire for a rejected key.
+    exc = error_from_response(status, {}, None)
+    assert type(exc) is expected
+    assert exc.detail == f"HTTP {status}"
+
+
+@pytest.mark.parametrize("status", [400, 422])
+def test_an_ambiguous_status_with_no_bucket_stays_the_base_class(status: int) -> None:
+    # 400 is either invalid_input or content_policy_violation, and those differ
+    # in whether a retry can ever succeed -- guessing would tell a caller to
+    # retry a deterministic refusal. 422 is pinned to no bucket at all.
+    exc = error_from_response(status, {}, None)
+    assert type(exc) is RouterError
+    assert exc.error_type == ""
+
+
+# -- never crash the client on a malformed response --------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        "<html>502 Bad Gateway</html>",
+        b"",
+        [],
+        {},
+        {"detail": None},
+        {"detail": 42},
+        {"detail": []},
+        {"detail": ["not an object", None, 7]},
+        {"detail": [{}]},
+        {"detail": [{"loc": "body", "msg": None, "type": 3, "ctx": "nope"}]},
+        {"error_type": 7, "detail": {"nested": "object"}},
+    ],
+)
+def test_a_malformed_body_degrades_instead_of_raising(body: Any) -> None:
+    exc = error_from_response(500, {REQUEST_ID_HEADER: REQUEST_ID}, body)
+    assert isinstance(exc, RouterError)
+    assert exc.request_id == REQUEST_ID
+    assert isinstance(exc.detail, str) and exc.detail
+    for entry in exc.errors:
+        assert isinstance(entry, ValidationErrorDetail)
+        assert isinstance(entry.msg, str)
+        assert isinstance(entry.type, str)
+
+
+def test_a_malformed_entry_keeps_the_fields_that_did_arrive() -> None:
+    exc = error_from_response(
+        422,
+        {ERROR_TYPE_HEADER: "invalid_input"},
+        {"detail": [{"msg": "field required", "type": "missing", "loc": None}]},
+    )
+    entry = exc.errors[0]
+    assert entry.msg == "field required"
+    assert entry.type == "missing"
+    assert entry.loc == ()
+
+
+def test_an_empty_header_value_is_treated_as_absent() -> None:
+    exc = error_from_response(403, {ERROR_TYPE_HEADER: "  ", REQUEST_ID_HEADER: " "}, None)
+    assert type(exc) is Forbidden  # from the status fallback, not the blank header
+    assert exc.request_id is None
+
+
+def test_no_headers_at_all_still_produces_an_exception() -> None:
+    exc = error_from_response(500, None, None)
+    assert type(exc) is RouterError
+    assert exc.request_id is None
+    assert exc.http_status == 500
+
+
+# -- the workflow-surface classes are a separate hierarchy -------------------
+
+
+def test_the_shared_names_are_not_the_workflow_surface_classes() -> None:
+    # comfy_sdk.Unauthorized is the workflow surface's. The router ones are
+    # imported from this module on purpose -- one name cannot be two classes.
+    from comfy_sdk import exceptions as workflow_exceptions
+
+    for router_cls, workflow_cls in (
+        (Unauthorized, workflow_exceptions.Unauthorized),
+        (Forbidden, workflow_exceptions.Forbidden),
+        (InsufficientCredits, workflow_exceptions.InsufficientCredits),
+    ):
+        assert router_cls is not workflow_cls
+        assert not issubclass(router_cls, workflow_cls)
+        assert issubclass(router_cls, RouterError)


### PR DESCRIPTION
## ELI-5

When a model run fails, the server says *why* in one short machine-readable word — `content_policy_violation`, `provider_timeout`, and nine others. Today a Python caller would have to compare that word to a string. This adds one exception class per word, so you write `except ContentPolicyViolation:` instead. Every one of them is also a `RouterError`, so you can catch them all at once when you don't care which. And when a newer server sends a word this version has never heard of, you still get a catchable exception with the word on it — the client does not fall over at the exact moment something has already gone wrong.

## What this adds

`src/comfy_sdk/router_exceptions.py` — the typed hierarchy for the `client.models` surface, plus `error_from_response(status, headers, body)`, which turns a response into the right exception.

**The intended class names, so both SDKs implement one list rather than two.** The rule is mechanical: **the class name is the PascalCase of the wire value, always.** `test_class_names_are_the_pascal_case_of_the_wire_value` asserts it over every class, so a hand-picked name cannot creep in later on either side.

| `error_type` | class | status |
|---|---|---|
| `invalid_input` | `InvalidInput` | 400 |
| `content_policy_violation` | `ContentPolicyViolation` | 400 |
| `provider_error` | `ProviderError` | 502 |
| `provider_timeout` | `ProviderTimeout` | 504 |
| `insufficient_credits` | `InsufficientCredits` | 402 |
| `model_not_found` | `ModelNotFound` | 404 |
| `unauthorized` | `Unauthorized` | 401 |
| `forbidden` | `Forbidden` | 403 |
| `concurrency_limit_exceeded` | `ConcurrencyLimitExceeded` | 429 |
| `client_disconnected` | `ClientDisconnected` | 499 |
| `internal_error` | `InternalError` | 500 |

Base is `RouterError`, which derives from `ComfyError`, so `except ComfyError` still covers the whole SDK. The three deferred types (`file_download_error`, `cancelled`, `queue_timeout`) are deliberately absent and a test pins their absence — adding one should be a decision someone makes on purpose, not a constant that quietly widens a set two SDKs generate from.

**Per-field validation detail survives as data.** A body whose `detail` is an *array* becomes `ValidationErrorDetail` entries on `.errors`, each with `loc` (a tuple, integer array indexes kept as ints), `msg`, `type`, `ctx` and `input`. `type` is where the specific provider reason lives — `image_too_small`, `file_too_large`, `missing` — which is the granularity the coarse bucket cannot express, so it is an open string rather than an enum. The exception message summarises the entries for a human *in addition to*, never instead of, the entries themselves.

**`X-Comfy-Request-Id` is on every exception built from a response**, as `.request_id`, so a user reporting a failure has the id to quote.

**An unrecognised `error_type` raises `RouterError` itself** with the raw value on `.error_type`, rather than failing to decode. Treat one like `internal_error`; because `InternalError` is also a `RouterError`, a caller who wrote the broad catch gets both.

## Judgment calls

- **The bucket is read off `X-Comfy-Error-Type` first, the body's `error_type` second.** The per-field validation body carries no `error_type` of its own, so the header is the only place its bucket appears. Written from one value by one writer server-side, the two cannot normally disagree; the header wins if they ever do.
- **A response carrying no bucket at all falls back to its status — but only for statuses that map to exactly one bucket.** A proxy or gateway that rejects a call before it reaches the router answers with a status and none of these headers, and `except Unauthorized` should still fire for a rejected key. `400` is deliberately *excluded*: it carries either `invalid_input` or `content_policy_violation`, and those differ in whether a retry can ever succeed — guessing between them would tell a caller to retry a deterministic refusal. `422` is excluded because the contract pins no bucket to it. Both fall through to `RouterError`, which is the honest answer. This mirrors the existing `comfy_low.errors._CODE_BY_STATUS` precedent in this repo.
- **`.errors` lives on the base class, not on one subclass.** The bucket a per-field failure carries is read off the header, and the server-side producer for that response is a later story, so the entries have to survive whichever bucket it turns out to be. Nothing in this change depends on guessing it.
- **Not re-exported from `comfy_sdk/__init__.py`, on purpose.** `Unauthorized`, `Forbidden` and `InsufficientCredits` already exist there for the workflow surface. One name cannot be two classes, and quietly redefining `comfy_sdk.Unauthorized` would change what an existing `except` clause catches. Import the router ones from `comfy_sdk.router_exceptions`, or catch `ComfyError` to cover both surfaces. A test pins that the two families stay distinct. If the preference is for a `comfy_sdk.models` sub-namespace instead, that is a one-line move and worth settling before the first release that ships it.
- **`error_from_response` never raises.** Every field is tolerated missing or wrongly-typed, because this code runs while already handling a failure — dropping the two fields that did arrive because a third was malformed helps nobody. 12 malformed-body shapes are tested, including `None`, an HTML string, `b""`, a bare list, and a `detail[]` entry whose every field has the wrong type.
- **No retry metadata.** Retry behaviour keyed on exception type is a separate story, and the contract declares no `Retry-After` on the 429, so nothing was invented here.

## What is deliberately NOT here

**This hierarchy is not yet wired to a call site, because there is no router call to wire it to.** `client.models` landed in #69 as the namespace plus a read-only view of the host client's configuration; it has no `run()` yet. `error_from_response` is therefore reachable only from tests today, and the story that adds the model-run call is the one that must route its error responses through it. That is the shape the ticket asks for — the exception hierarchy lands first, generated against the server-side mapping — but it is the one thing a reviewer should not assume is covered.

## Verification of the name list — the part that could not be taken on faith

The whole value of these names is that they match the server's set exactly, and a wrong string fails *silently*: every exception would degrade to the base class and no caller's `except` clause would ever fire. So the eleven values were not inferred from the story text. They were read off the authoritative server-side `error_type` declaration and the canonical API contract that defines the two error body shapes and the two response headers, and cross-checked against each other: the six request-level buckets, the five transport-level ones, the three deferred values held out, the per-field entry's `loc`/`msg`/`type`/`ctx`/`input` fields, and the status paired with each bucket (which is where this PR's status column and the status-fallback table come from). No value in this change is a guess.

The TypeScript SDK has **not** implemented its half yet — there is no `error_type` or router error handling on its `main` today — so this list is the proposal it should mirror, not a match against an existing one. That cross-check is still open.

## Unexercised artifacts

- The two linked design documents are on an internal collaboration tool this environment cannot reach; neither was read.
- No live router endpoint was called. The surface is unreleased and this SDK's vendored `spec/openapi.yaml` (v2.0.0) does not carry the router routes at all, so `scripts/check_drift.py` does not cover this module and every test drives a stubbed response rather than a server.
- No sibling story's description was available; only their titles.

## Verification

`pytest` 258 passed / 4 skipped (78 of them new). `ruff check`, `ruff format --check`, `mypy src`, `python3 scripts/check_drift.py` and `python3 scripts/check_public_repo_hygiene.py` all clean.

One note for whoever runs the checks locally: `uv run ruff …` without `--extra dev` resolves an *unpinned* ruff, and a newer ruff reformats the Python code blocks inside `README.md`, which the pinned `ruff~=0.15.22` does not touch. That produced an unrelated 24-line README diff here that was reverted. Use `uv run --extra dev ruff …`, which is what CI installs.

## Provenance
- **Authored by:** agent-work loop
- **Verified:** pytest: 258 passed, 4 skipped; ruff check: clean; ruff format --check: 46 files already formatted; mypy src: no issues in 18 files; check_drift.py: in sync; check_public_repo_hygiene.py: no internal-only references
- **Deviations:** the "class names match the TypeScript SDK's exactly" criterion is met only as a proposal — the TypeScript SDK has not implemented its hierarchy yet, so this states the list rather than matching an existing one. The hierarchy is not wired to a call site because the model-run call does not exist yet (see "What is deliberately NOT here"). No other criterion was skipped.
