### PR TITLE
feat: add expires_in parameter to asset upload endpoints

### DIFF
--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -391,6 +391,7 @@ class ComfyLow:
         tags: list[str] | None = None,
         idempotency_key: str | None = None,
         file_size: int | None = None,
+        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         """POST /api/v2/assets — streaming multipart upload."""
@@ -406,6 +407,8 @@ class ComfyLow:
             # One part per tag — repeating the field name is the multipart/form
             # convention for a list, and a dict would silently drop all but one.
             fields.extend(("tags", t) for t in tags)
+        if expires_in is not None:
+            fields.append(("expires_in", str(expires_in)))
         boundary = _new_boundary()
         body, length = _multipart.build_multipart(
             boundary,
@@ -430,6 +433,7 @@ class ComfyLow:
         *,
         file_path: str | None = None,
         tags: list[str] | None = None,
+        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         """POST /api/v2/assets/from-hash — dedup mint over existing bytes."""
@@ -438,6 +442,8 @@ class ComfyLow:
             payload["file_path"] = file_path
         if tags is not None:
             payload["tags"] = tags
+        if expires_in is not None:
+            payload["expires_in"] = expires_in
         resp = self.raw_request("POST", "/assets/from-hash", json=payload, timeout=timeout)
         data = self._p.parse_or_raise(resp, (200, 201))
         return Asset.model_validate(data)
@@ -727,6 +733,7 @@ class AsyncComfyLow:
         tags: list[str] | None = None,
         idempotency_key: str | None = None,
         file_size: int | None = None,
+        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         if file_size is None:
@@ -740,6 +747,8 @@ class AsyncComfyLow:
         if tags:
             # One part per tag — see the sync ``post_assets`` for why a dict is wrong.
             fields.extend(("tags", t) for t in tags)
+        if expires_in is not None:
+            fields.append(("expires_in", str(expires_in)))
         boundary = _new_boundary()
         body, length = _multipart.build_multipart(
             boundary,
@@ -774,6 +783,7 @@ class AsyncComfyLow:
         *,
         file_path: str | None = None,
         tags: list[str] | None = None,
+        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         payload: dict[str, Any] = {"hash": hash}
@@ -781,6 +791,8 @@ class AsyncComfyLow:
             payload["file_path"] = file_path
         if tags is not None:
             payload["tags"] = tags
+        if expires_in is not None:
+            payload["expires_in"] = expires_in
         resp = await self.raw_request("POST", "/assets/from-hash", json=payload, timeout=timeout)
         data = self._p.parse_or_raise(resp, (200, 201))
         return Asset.model_validate(data)

--- a/src/comfy_sdk/assets.py
+++ b/src/comfy_sdk/assets.py
@@ -42,6 +42,7 @@ class _Source:
     file_path: str
     hasher: Hasher
     opener: Opener
+    expires_in: int | None = None
 
 
 def _guess_content_type(name: str | None) -> str:
@@ -60,6 +61,7 @@ class _AssetBase:
         self._file_path = source.file_path
         self._hasher = source.hasher
         self._opener = source.opener
+        self._expires_in = source.expires_in
         self._hash: str | None = None
         self._id: str | None = None
         self._created_new: bool | None = None
@@ -127,7 +129,9 @@ class Asset(_AssetBase):
         digest = self.hash
         with translating():
             if self._low.head_asset_by_hash(digest):
-                asset = self._low.asset_from_hash(digest, file_path=self._file_path)
+                asset = self._low.asset_from_hash(
+                    digest, file_path=self._file_path, expires_in=self._expires_in
+                )
             else:
                 fh, size = self._opener()
                 try:
@@ -138,6 +142,7 @@ class Asset(_AssetBase):
                         expected_hash=digest,
                         idempotency_key=self._idempotency_key,
                         file_size=size,
+                        expires_in=self._expires_in,
                     )
                 finally:
                     fh.close()
@@ -173,7 +178,9 @@ class AsyncAsset(_AssetBase):
         digest = self.hash
         with translating():
             if await self._low.head_asset_by_hash(digest):
-                asset = await self._low.asset_from_hash(digest, file_path=self._file_path)
+                asset = await self._low.asset_from_hash(
+                    digest, file_path=self._file_path, expires_in=self._expires_in
+                )
             else:
                 fh, size = self._opener()
                 try:
@@ -184,6 +191,7 @@ class AsyncAsset(_AssetBase):
                         expected_hash=digest,
                         idempotency_key=self._idempotency_key,
                         file_size=size,
+                        expires_in=self._expires_in,
                     )
                 finally:
                     fh.close()
@@ -208,7 +216,7 @@ class AsyncAsset(_AssetBase):
 # ---- source builders (shared, sans-IO except explicit reads) ------------
 
 
-def _file_source(path: str | PathLike[str]) -> _Source:
+def _file_source(path: str | PathLike[str], *, expires_in: int | None = None) -> _Source:
     p = str(path)
     name = basename(p)
     return _Source(
@@ -216,6 +224,7 @@ def _file_source(path: str | PathLike[str]) -> _Source:
         file_path=name,
         hasher=lambda: _hashing.hash_file(p),
         opener=lambda: (open(p, "rb"), getsize(p)),
+        expires_in=expires_in,
     )
 
 
@@ -235,8 +244,8 @@ class AssetFactory:
     def __init__(self, low: ComfyLow) -> None:
         self._low = low
 
-    def from_file(self, path: str | PathLike[str]) -> Asset:
-        return Asset(self._low, _file_source(path))
+    def from_file(self, path: str | PathLike[str], *, expires_in: int | None = None) -> Asset:
+        return Asset(self._low, _file_source(path, expires_in=expires_in))
 
     def from_bytes(
         self,
@@ -288,8 +297,8 @@ class AsyncAssetFactory:
     def __init__(self, low: AsyncComfyLow) -> None:
         self._low = low
 
-    def from_file(self, path: str | PathLike[str]) -> AsyncAsset:
-        return AsyncAsset(self._low, _file_source(path))
+    def from_file(self, path: str | PathLike[str], *, expires_in: int | None = None) -> AsyncAsset:
+        return AsyncAsset(self._low, _file_source(path, expires_in=expires_in))
 
     def from_bytes(
         self,


### PR DESCRIPTION
- Add expires_in to post_assets, asset_from_hash, async equivalents
- Add expires_in to _Source, AssetFactory.from_file, AsyncAssetFactory.from_file
- Pass expires_in through upload/from-hash flows