### PR TITLE
feat: retry a model run under one Idempotency-Key so a retry cannot double-charge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ notes for each version.
 
 ### Added
 
+- Automatic retry for `client.models.run`, on by default, with the
+  `Idempotency-Key` sent unconditionally on **every** attempt of one logical
+  call — a new call mints a new key. That is what keeps a retry from being
+  billed as a second generation. Retried: 5xx responses and connect-phase
+  transport failures. Not retried: every 4xx (a deterministic refusal such as
+  `content_policy_violation`, `404`, `409` or `422` cannot change on the second
+  ask), `429` (it names its own pace in `Retry-After`), and — unless
+  `retry_possibly_in_flight=True` — a failure that leaves the request's fate
+  unknown, most importantly a client-side timeout on a run the server may still
+  be generating. The budget is 60 seconds of **total elapsed time** from the
+  first attempt rather than an attempt count, and it bounds when the last
+  attempt may *start*: an attempt already running is never interrupted, so a
+  slow generation is never abandoned half-way. Backoff is 0.5s doubling to a
+  15s ceiling with full jitter. Configure with `Comfy(retry=RetryPolicy(...))`
+  or switch it off with `Comfy(retry=NO_RETRY)`; `client.models.retry` reads
+  back the policy in force. `RetryPolicy`, `DEFAULT_RETRY` and `NO_RETRY` are
+  exported from `comfy_sdk`.
 - `client.models.run(model, arguments)` on both `Comfy` and `AsyncComfy` — one
   call that returns the completed generation. Where the platform has to
   submit-and-poll an upstream provider, that polling happens server side inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,29 @@ notes for each version.
 - Automatic retry for `client.models.run`, on by default, with the
   `Idempotency-Key` sent unconditionally on **every** attempt of one logical
   call — a new call mints a new key. That is what keeps a retry from being
-  billed as a second generation. Retried: 5xx responses and connect-phase
-  transport failures. Not retried: every 4xx (a deterministic refusal such as
-  `content_policy_violation`, `404`, `409` or `422` cannot change on the second
-  ask), `429` (it names its own pace in `Retry-After`), and — unless
-  `retry_possibly_in_flight=True` — a failure that leaves the request's fate
-  unknown, most importantly a client-side timeout on a run the server may still
-  be generating. The budget is 60 seconds of **total elapsed time** from the
-  first attempt rather than an attempt count, and it bounds when the last
-  attempt may *start*: an attempt already running is never interrupted, so a
-  slow generation is never abandoned half-way. Backoff is 0.5s doubling to a
-  15s ceiling with full jitter. Configure with `Comfy(retry=RetryPolicy(...))`
-  or switch it off with `Comfy(retry=NO_RETRY)`; `client.models.retry` reads
-  back the policy in force. `RetryPolicy`, `DEFAULT_RETRY` and `NO_RETRY` are
-  exported from `comfy_sdk`.
+  billed as a second generation, and it is also what decides which failures are
+  retried at all: the key is single-use and reject-on-duplicate with no
+  response replay, so only failures that leave it unclaimed are worth another
+  attempt. Retried by default: connect-phase transport failures (the request
+  never reached the server), and a `429` carrying `Retry-After` (a reject that
+  started no work, so the key is released) — paced by the `Retry-After` the
+  server sent rather than a blind backoff. Not retried: every other 4xx, since
+  a deterministic refusal such as `content_policy_violation`, `404`, `409` or
+  `422` cannot change on the second ask. Not retried unless
+  `retry_possibly_in_flight=True`: anything whose outcome is unknown — a 5xx
+  response, or a client-side timeout on a run the server may still be
+  generating — because the key stays claimed across those and a same-key retry
+  would come back `422 idempotency_key_reuse` in place of the real error. Turn
+  the opt-in on for a deployment that replays a repeated key. The budget is 60
+  seconds of **total elapsed time** from the first attempt rather than an
+  attempt count, and it bounds when the last attempt may *start*: an attempt
+  already running is never interrupted, so a slow generation is never abandoned
+  half-way. Backoff is 0.5s doubling to a 15s ceiling with full jitter, clamped
+  to whatever is left of the budget. Configure with
+  `Comfy(retry=RetryPolicy(...))` or switch it off with
+  `Comfy(retry=NO_RETRY)`; `client.models.retry` reads back the policy in
+  force. `RetryPolicy`, `DEFAULT_RETRY` and `NO_RETRY` are exported from
+  `comfy_sdk`.
 - `client.models.run(model, arguments)` on both `Comfy` and `AsyncComfy` — one
   call that returns the completed generation. Where the platform has to
   submit-and-poll an upstream provider, that polling happens server side inside

--- a/README.md
+++ b/README.md
@@ -406,6 +406,56 @@ indefinitely. Each call also sends a fresh `Idempotency-Key`, so an accidental
 exact resend is rejected by the server instead of billing a second generation;
 pass `idempotency_key=` to choose the value yourself.
 
+### Retrying a run without paying for it twice
+
+A failed `models.run` is retried automatically. **Every attempt of one call
+sends the same `Idempotency-Key`**, and a new call mints a new one — that is
+what lets a server tell a retry apart from a second order, on a surface where
+one call is a billed generation.
+
+The default policy:
+
+| Condition | Behaviour |
+|---|---|
+| Retried | 5xx responses, and connect-phase transport failures (connection refused, connect timeout, no pooled connection, proxy error) |
+| Not retried | every 4xx — `400`/`content_policy_violation`, `404`, `409`, `422`, `401`, `402` — because asking again cannot change a deterministic refusal. `429` is also left alone: it names its own pace in `Retry-After` rather than wanting a blind backoff |
+| Not retried by default | a failure that leaves the request's fate unknown — most importantly a client-side timeout, where the server may still be generating |
+| Budget | 60 seconds of **total elapsed time** from the first attempt, not a number of attempts |
+| Backoff | 0.5s doubling to a 15s ceiling, with full jitter (each wait is drawn from `[0, ceiling]`) |
+
+The budget bounds when the *last* attempt may **start**; an attempt already
+running is never interrupted by it, so a slow generation is never abandoned
+half-way. The worst-case wall clock for a call is therefore the budget plus one
+`timeout`.
+
+Tune or disable it per client:
+
+```python
+from comfy_sdk import Comfy, NO_RETRY, RetryPolicy
+
+Comfy(retry=NO_RETRY)                          # exactly one attempt, ever
+Comfy(retry=RetryPolicy(max_elapsed=300.0))    # keep trying for five minutes
+
+client.models.retry                            # the policy in force, read-only
+```
+
+A client-side timeout is the one case left out by default. `run` holds the
+connection open while the server generates, so a timeout means "no answer yet",
+not "it did not happen" — retrying it starts a second generation unless the
+server replays the repeated key rather than re-running it. Against a server
+that does replay, opt in:
+
+```python
+Comfy(retry=RetryPolicy(max_elapsed=1200.0, retry_possibly_in_flight=True))
+```
+
+Raise `max_elapsed` when you do: one full-length client timeout on a run can
+spend the default 60-second budget on its own, leaving no room for the retry
+you just asked for.
+
+`retry` governs `client.models` only. `submit()`/`run()` on the client keep
+their own 429 handling, which follows the server's `Retry-After`.
+
 ## Sync and async
 
 `Comfy` and `AsyncComfy` expose the identical surface — swap the import and

--- a/README.md
+++ b/README.md
@@ -413,15 +413,26 @@ sends the same `Idempotency-Key`**, and a new call mints a new one — that is
 what lets a server tell a retry apart from a second order, on a surface where
 one call is a billed generation.
 
+That one key is also what decides *which* failures are worth retrying. The API
+contract makes `Idempotency-Key` **single-use, reject-on-duplicate, with no
+response replay**: the first request to present a key is processed, and a later
+one presenting the same key is rejected `422 idempotency_key_reuse` rather than
+re-run. The contract also says when the key is released instead of claimed — a
+request that definitively failed without starting work frees its key, while one
+whose outcome the server could not characterise (a 5xx, an upstream timeout)
+keeps it. Retrying under one key is only safe where that key is still unspent,
+so that is exactly what the default policy retries.
+
 The default policy:
 
 | Condition | Behaviour |
 |---|---|
-| Retried | 5xx responses, and connect-phase transport failures (connection refused, connect timeout, no pooled connection, proxy error) |
-| Not retried | every 4xx — `400`/`content_policy_violation`, `404`, `409`, `422`, `401`, `402` — because asking again cannot change a deterministic refusal. `429` is also left alone: it names its own pace in `Retry-After` rather than wanting a blind backoff |
-| Not retried by default | a failure that leaves the request's fate unknown — most importantly a client-side timeout, where the server may still be generating |
+| Retried | connect-phase transport failures (connection refused, connect timeout, no pooled connection, proxy error) — the request never reached the server, so the key was never claimed |
+| Retried, at the server's pace | a `429` carrying `Retry-After` (queue full, out of credits, a concurrency limit) — a reject that started no work, so the key is released. The delay is the one the server named, not a guess |
+| Not retried | every other 4xx — `400`/`content_policy_violation`, `404`, `409`, `422`, `401`, `402` — because asking again cannot change a deterministic refusal. A `429` with no `Retry-After` is not asking to be asked again either |
+| Not retried by default | anything whose outcome is unknown: a **5xx response**, and a client-side timeout where the server may still be generating. The key stays claimed for these, so a same-key retry comes back `422 idempotency_key_reuse` and hides the real error — while a fresh-key retry is the second billed generation the one-key rule exists to prevent |
 | Budget | 60 seconds of **total elapsed time** from the first attempt, not a number of attempts |
-| Backoff | 0.5s doubling to a 15s ceiling, with full jitter (each wait is drawn from `[0, ceiling]`) |
+| Backoff | 0.5s doubling to a 15s ceiling, with full jitter (each wait is drawn from `[0, ceiling]`), clamped to whatever is left of the budget |
 
 The budget bounds when the *last* attempt may **start**; an attempt already
 running is never interrupted by it, so a slow generation is never abandoned
@@ -439,11 +450,12 @@ Comfy(retry=RetryPolicy(max_elapsed=300.0))    # keep trying for five minutes
 client.models.retry                            # the policy in force, read-only
 ```
 
-A client-side timeout is the one case left out by default. `run` holds the
-connection open while the server generates, so a timeout means "no answer yet",
-not "it did not happen" — retrying it starts a second generation unless the
-server replays the repeated key rather than re-running it. Against a server
-that does replay, opt in:
+5xx responses and client-side timeouts are the cases left out by default, and
+for the same reason. `run` holds the connection open while the server
+generates, so neither one tells you whether the generation happened — retrying
+either starts a second generation unless the server replays the repeated key
+rather than re-running it, and against a server that *rejects* it instead the
+retry simply cannot succeed. Against a deployment that does replay, opt in:
 
 ```python
 Comfy(retry=RetryPolicy(max_elapsed=1200.0, retry_possibly_in_flight=True))

--- a/src/comfy_sdk/__init__.py
+++ b/src/comfy_sdk/__init__.py
@@ -59,6 +59,7 @@ from .exceptions import (
 )
 from .jobs import AsyncJob, Job, JobWorkflow
 from .outputs import AsyncOutput, DownloadUrl, Output
+from .retry import DEFAULT_RETRY, NO_RETRY, RetryPolicy
 from .workflows import Workflow, WorkflowFactory
 
 try:
@@ -111,4 +112,8 @@ __all__ = [
     "MissingApiKey",
     "Unauthorized",
     "Forbidden",
+    # retry policy
+    "RetryPolicy",
+    "DEFAULT_RETRY",
+    "NO_RETRY",
 ]

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -43,6 +43,7 @@ from .assets import AssetFactory, AsyncAssetFactory
 from .exceptions import MissingApiKey, WorkflowFormatUi, to_sdk_error
 from .jobs import AsyncJob, AsyncJobFactory, Job, JobFactory
 from .models import AsyncModels, Models
+from .retry import DEFAULT_RETRY, RetryPolicy
 from .workflows import Workflow, WorkflowFactory
 
 # How long to keep retrying a full queue before giving up (seconds).
@@ -179,6 +180,12 @@ class Comfy:
     fails loudly instead of being read as a key. Omit it to fall back to
     ``COMFY_API_KEY``; against Comfy Cloud, neither raises
     :class:`~comfy_sdk.exceptions.MissingApiKey` at construction.
+
+    ``retry`` is the policy ``client.models`` calls fail under —
+    :data:`~comfy_sdk.retry.DEFAULT_RETRY` unless replaced, and
+    :data:`~comfy_sdk.retry.NO_RETRY` to make every call exactly one attempt.
+    It does not govern ``submit``/``run``, whose 429 handling follows the
+    server's own ``Retry-After`` instead.
     """
 
     def __init__(
@@ -187,6 +194,7 @@ class Comfy:
         api_key: str | None = None,
         timeout: float | None = 30.0,
         client_info: str | None = None,
+        retry: RetryPolicy = DEFAULT_RETRY,
     ) -> None:
         base_url = _resolve_base_url()
         key = _resolve_api_key(api_key, base_url)
@@ -195,8 +203,9 @@ class Comfy:
         self.workflows = WorkflowFactory()
         self.jobs = JobFactory(self._low)
         #: ``client.models`` — the model namespace, sharing this client's
-        #: transport (credentials, base URL, connection pool, timeout).
-        self.models = Models(self._low)
+        #: transport (credentials, base URL, connection pool, timeout) and its
+        #: retry policy.
+        self.models = Models(self._low, retry)
 
     def close(self) -> None:
         """Release the underlying HTTP connection pool.
@@ -311,6 +320,7 @@ class AsyncComfy:
         api_key: str | None = None,
         timeout: float | None = 30.0,
         client_info: str | None = None,
+        retry: RetryPolicy = DEFAULT_RETRY,
     ) -> None:
         base_url = _resolve_base_url()
         key = _resolve_api_key(api_key, base_url)
@@ -319,7 +329,7 @@ class AsyncComfy:
         self.workflows = WorkflowFactory()
         self.jobs = AsyncJobFactory(self._low)
         #: Async counterpart of :attr:`Comfy.models`, on this client's transport.
-        self.models = AsyncModels(self._low)
+        self.models = AsyncModels(self._low, retry)
 
     async def aclose(self) -> None:
         """Async :meth:`Comfy.close`. Prefer ``async with AsyncComfy(...)``."""

--- a/src/comfy_sdk/models.py
+++ b/src/comfy_sdk/models.py
@@ -45,14 +45,23 @@ from comfy_low.transport import MODEL_RUN_TIMEOUT, AsyncComfyLow, ComfyLow
 from ._core import new_idempotency_key
 from .exceptions import translating
 from .retry import DEFAULT_RETRY, Retrier, RetryPolicy
+from .router_exceptions import RouterError
 
 #: Failures the policy is even asked about. A protocol ``ApiError`` is a
-#: response the server sent; an ``httpx.TransportError`` is no response at all.
-#: Being in this tuple is not "retryable" — most of these are not, and
-#: :meth:`RetryPolicy.should_retry` decides which. What it buys is that
-#: anything *else* propagates untouched, so a bug in the SDK itself is never
-#: mistaken for a flaky network and quietly re-run.
-_CANDIDATE_FAILURES = (ApiError, httpx.TransportError)
+#: response the server sent, a ``RouterError`` is the same thing modelled by
+#: this surface's own typed hierarchy, and an ``httpx.TransportError`` is no
+#: response at all. Being in this tuple is not "retryable" — most of these are
+#: not, and :meth:`RetryPolicy.should_retry` decides which. What it buys is
+#: that anything *else* propagates untouched, so a bug in the SDK itself is
+#: never mistaken for a flaky network and quietly re-run.
+#:
+#: ``RouterError`` is listed even though ``post_model_run`` raises ``ApiError``
+#: today: the typed errors in :mod:`comfy_sdk.router_exceptions` were built for
+#: this very surface and derive from ``ComfyError``, not ``ApiError``, so
+#: omitting them would make :meth:`RetryPolicy.should_retry`'s router branch
+#: unreachable and turn retry into a silent no-op the day this route starts
+#: raising them, with no test failing.
+_CANDIDATE_FAILURES = (ApiError, RouterError, httpx.TransportError)
 
 _now = time.monotonic
 
@@ -127,24 +136,32 @@ class Models(_ModelsBase):
         call unless ``idempotency_key`` is given, so an accidental exact resend
         is the server's to reject rather than a second charged generation.
 
-        A failed attempt is retried under the client's policy — 5xx and
-        connect-phase failures, backed off with jitter and bounded by total
-        elapsed time. **Every attempt of this one call reuses the one key**,
-        which is what stops a retry from being billed as a second generation;
-        calling ``run`` again is a new call and mints a new key. See
+        A failed attempt is retried under the client's policy, backed off with
+        jitter and bounded by total elapsed time. **Every attempt of this one
+        call reuses the one key**, which is what stops a retry from being
+        billed as a second generation; calling ``run`` again is a new call and
+        mints a new key. Because the key is single-use and reject-on-duplicate,
+        only failures that leave it unclaimed are retried by default —
+        connect-phase failures, and a ``429`` that names a ``Retry-After``. A
+        completed 5xx or a client-side timeout leaves the outcome unknown, and
+        with it the key claimed, so those need
+        ``RetryPolicy(retry_possibly_in_flight=True)``. See
         :mod:`comfy_sdk.retry`, and ``Comfy(retry=NO_RETRY)`` to switch it off.
         """
         low = cast(ComfyLow, self._low)
         # Minted once, outside the loop: reusing this exact value on every
         # attempt is the whole reason a retry here is not a second charge.
         key = idempotency_key or new_idempotency_key()
+        # Snapshotted for the same reason the key is. Re-reading the caller's
+        # mapping inside each attempt would let a mutation between attempts
+        # send a different body under the *same* key, which is precisely the
+        # same-key-different-body case the contract rejects outright.
+        payload = dict(arguments)
         retrier = Retrier(self._retry, now=_now)
         with translating():
             while True:
                 try:
-                    return low.post_model_run(
-                        model, arguments, idempotency_key=key, timeout=timeout
-                    )
+                    return low.post_model_run(model, payload, idempotency_key=key, timeout=timeout)
                 except _CANDIDATE_FAILURES as exc:
                     delay = retrier.delay_before_retry(exc)
                     if delay is None:
@@ -175,12 +192,16 @@ class AsyncModels(_ModelsBase):
         """
         low = cast(AsyncComfyLow, self._low)
         key = idempotency_key or new_idempotency_key()
+        # Snapshotted before the first attempt — see :meth:`Models.run`. The
+        # window is wider here: the caller's coroutine can mutate `arguments`
+        # while the retry sleeps.
+        payload = dict(arguments)
         retrier = Retrier(self._retry, now=_now)
         with translating():
             while True:
                 try:
                     return await low.post_model_run(
-                        model, arguments, idempotency_key=key, timeout=timeout
+                        model, payload, idempotency_key=key, timeout=timeout
                     )
                 except _CANDIDATE_FAILURES as exc:
                     delay = retrier.delay_before_retry(exc)

--- a/src/comfy_sdk/models.py
+++ b/src/comfy_sdk/models.py
@@ -12,6 +12,12 @@ different timeout) is visible through ``models`` with no re-wiring. v1 is the
 namespace plus a read-only view of that shared configuration; model operations
 are added to this object as they land, never to a parallel client.
 
+The namespace also carries the client's retry policy, for the same reason it
+carries its transport: a retry is part of how a call is made, not a per-call
+decision a caller should have to repeat. See :mod:`comfy_sdk.retry` for what is
+retried and why one logical call keeps one ``Idempotency-Key`` across every
+attempt.
+
 ``run`` is the one model operation today, and it exists in exactly one form per
 client: ``Comfy().models.run(...)`` blocks, ``AsyncComfy().models.run(...)`` is
 awaited. **The awaitable form is the async client, not a suffixed method** —
@@ -26,21 +32,36 @@ the only entry point, and ``client.models`` is the whole surface.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from collections.abc import Mapping
 from typing import Any, cast
 
 import httpx
 
+from comfy_low.errors import ApiError
 from comfy_low.transport import MODEL_RUN_TIMEOUT, AsyncComfyLow, ComfyLow
 
 from ._core import new_idempotency_key
 from .exceptions import translating
+from .retry import DEFAULT_RETRY, Retrier, RetryPolicy
+
+#: Failures the policy is even asked about. A protocol ``ApiError`` is a
+#: response the server sent; an ``httpx.TransportError`` is no response at all.
+#: Being in this tuple is not "retryable" — most of these are not, and
+#: :meth:`RetryPolicy.should_retry` decides which. What it buys is that
+#: anything *else* propagates untouched, so a bug in the SDK itself is never
+#: mistaken for a flaky network and quietly re-run.
+_CANDIDATE_FAILURES = (ApiError, httpx.TransportError)
+
+_now = time.monotonic
 
 
 class _ModelsBase:
     """Read-only view of the configuration inherited from the host client."""
 
     _low: ComfyLow | AsyncComfyLow
+    _retry: RetryPolicy
 
     @property
     def base_url(self) -> str:
@@ -51,6 +72,11 @@ class _ModelsBase:
     def timeout(self) -> httpx.Timeout:
         """The host client's HTTP timeout, read live from its transport."""
         return self._low.timeout
+
+    @property
+    def retry(self) -> RetryPolicy:
+        """The host client's retry policy — what a failed attempt is worth."""
+        return self._retry
 
     def __repr__(self) -> str:
         # Redacted like the host client's repr: a base URL may carry proxy
@@ -66,8 +92,9 @@ class Models(_ModelsBase):
     what makes the configuration shared rather than duplicated.
     """
 
-    def __init__(self, low: ComfyLow) -> None:
+    def __init__(self, low: ComfyLow, retry: RetryPolicy = DEFAULT_RETRY) -> None:
         self._low = low
+        self._retry = retry
 
     def run(
         self,
@@ -99,22 +126,38 @@ class Models(_ModelsBase):
         An ``Idempotency-Key`` is sent on every run; a fresh one is minted per
         call unless ``idempotency_key`` is given, so an accidental exact resend
         is the server's to reject rather than a second charged generation.
+
+        A failed attempt is retried under the client's policy — 5xx and
+        connect-phase failures, backed off with jitter and bounded by total
+        elapsed time. **Every attempt of this one call reuses the one key**,
+        which is what stops a retry from being billed as a second generation;
+        calling ``run`` again is a new call and mints a new key. See
+        :mod:`comfy_sdk.retry`, and ``Comfy(retry=NO_RETRY)`` to switch it off.
         """
         low = cast(ComfyLow, self._low)
+        # Minted once, outside the loop: reusing this exact value on every
+        # attempt is the whole reason a retry here is not a second charge.
+        key = idempotency_key or new_idempotency_key()
+        retrier = Retrier(self._retry, now=_now)
         with translating():
-            return low.post_model_run(
-                model,
-                arguments,
-                idempotency_key=idempotency_key or new_idempotency_key(),
-                timeout=timeout,
-            )
+            while True:
+                try:
+                    return low.post_model_run(
+                        model, arguments, idempotency_key=key, timeout=timeout
+                    )
+                except _CANDIDATE_FAILURES as exc:
+                    delay = retrier.delay_before_retry(exc)
+                    if delay is None:
+                        raise
+                    time.sleep(delay)
 
 
 class AsyncModels(_ModelsBase):
     """``client.models`` on :class:`~comfy_sdk.client.AsyncComfy` — mirrors :class:`Models`."""
 
-    def __init__(self, low: AsyncComfyLow) -> None:
+    def __init__(self, low: AsyncComfyLow, retry: RetryPolicy = DEFAULT_RETRY) -> None:
         self._low = low
+        self._retry = retry
 
     async def run(
         self,
@@ -127,13 +170,20 @@ class AsyncModels(_ModelsBase):
         """Awaitable :meth:`Models.run` — same arguments, same result shape.
 
         This *is* the async form of ``run``: awaiting it on ``AsyncComfy`` is
-        the whole difference from the sync client. See :meth:`Models.run`.
+        the whole difference from the sync client — including the retry policy
+        and the one-key-per-call rule. See :meth:`Models.run`.
         """
         low = cast(AsyncComfyLow, self._low)
+        key = idempotency_key or new_idempotency_key()
+        retrier = Retrier(self._retry, now=_now)
         with translating():
-            return await low.post_model_run(
-                model,
-                arguments,
-                idempotency_key=idempotency_key or new_idempotency_key(),
-                timeout=timeout,
-            )
+            while True:
+                try:
+                    return await low.post_model_run(
+                        model, arguments, idempotency_key=key, timeout=timeout
+                    )
+                except _CANDIDATE_FAILURES as exc:
+                    delay = retrier.delay_before_retry(exc)
+                    if delay is None:
+                        raise
+                    await asyncio.sleep(delay)

--- a/src/comfy_sdk/retry.py
+++ b/src/comfy_sdk/retry.py
@@ -15,23 +15,60 @@ retry as the same request rather than a second order. The key is sent
 unconditionally — there is no configuration that turns it off — because a retry
 without it is exactly the double-charge above.
 
-**A retry never begins while the original attempt might still be running on the
-server.** The client cannot observe the server's side of an aborted request, so
-this is enforced structurally rather than by guessing:
+**Only failures the key survives are retried by default.** Every documented
+statement this repo makes about ``Idempotency-Key`` says it is *single-use,
+reject-on-duplicate, with no response replay* — ``spec/openapi.yaml``'s shared
+``IdempotencyKey`` parameter, :class:`~comfy_sdk.exceptions.IdempotencyKeyReuse`
+and the README all agree that a later request presenting the same key is
+rejected ``422`` ``idempotency_key_reuse`` rather than re-run or replayed. The
+spec is equally explicit about when a key is *released* instead of claimed: a
+request that "definitively fails without creating a job (a validation error, or
+an upstream reject such as out-of-credits or queue-full)" frees it, while one
+whose outcome the server cannot characterise ("an upstream timeout or 5xx where
+the job may or may not have been created") keeps it claimed.
 
-1. Attempts are strictly sequential. One attempt's connection is closed and its
-   backoff has elapsed before the next is opened; two attempts of one logical
-   call are never in flight at once.
-2. The retry deadline never interrupts an attempt. It is checked only *between*
-   attempts, so the SDK never abandons a request that is merely slow — the
-   per-attempt ``timeout`` is the only thing that ends an attempt, and on a run
-   that is the long, generation-sized timeout rather than an ordinary API one.
-3. A failure that leaves the request's fate *unknown* — no response arrived, so
-   the server may still be generating — is not retried by default. Only
-   failures where this attempt provably finished are: a completed 5xx response,
-   or a connect-phase failure that never delivered the request at all. Opting
-   in is :attr:`RetryPolicy.retry_possibly_in_flight`, and it is safe once the
-   server replays a repeated ``Idempotency-Key`` rather than re-running it.
+``POST /models/run`` is not itself in that spec, so its key semantics are
+undocumented — which is the point. Retrying under one key is only safe against a
+server that *replays* a claimed key, and nothing here says this route does; the
+alternatives are a ``422`` that replaces the real error, or a second billed
+generation. So the SDK retries by default only where the key is provably still
+unspent, and leaves the rest to an explicit opt-in.
+
+That, not a guess about the network, is what sorts the failures:
+
+1. **Never delivered** — the connection was refused, timed out before it was
+   established, or never came out of the pool. The request never reached
+   submission, so the key was never claimed and the same key is still
+   spendable. Retried by default; this is the one class where one-key retry is
+   provably free.
+2. **Rejected without starting work** — a ``429`` that names a pace in
+   ``Retry-After``. The contract releases the key for exactly this (queue-full,
+   out-of-credits, a concurrency limit) and tells clients to treat "429 +
+   ``Retry-After``" as back-off-and-retry, so it is retried by default at the
+   pace the server asked for rather than a blind backoff of our own.
+3. **Outcome unknown** — a completed 5xx, or a transport failure that may have
+   delivered the request in full (a read timeout on a run is the important
+   member: the generation-sized client timeout expired with no answer, which is
+   precisely when the server is most likely still generating). This is the
+   class the spec keeps the key claimed for, so a same-key retry here is a
+   ``422`` that replaces the real error — and a *fresh*-key retry is the second
+   billed generation this module exists to prevent. Not retried by default.
+   :attr:`RetryPolicy.retry_possibly_in_flight` opts in, and it is correct
+   exactly when a deployment replays a repeated key instead of rejecting it.
+4. **Everything else** — every other 4xx is the server's considered answer
+   about *this* request, and asking again spends money to be refused again.
+   Never retried.
+
+**A retry never begins while the original attempt might still be running on the
+server.** Beyond the classification above this is also enforced structurally:
+
+* Attempts are strictly sequential. One attempt's connection is closed and its
+  backoff has elapsed before the next is opened; two attempts of one logical
+  call are never in flight at once.
+* The retry deadline never interrupts an attempt. It is checked only *between*
+  attempts, so the SDK never abandons a request that is merely slow — the
+  per-attempt ``timeout`` is the only thing that ends an attempt, and on a run
+  that is the long, generation-sized timeout rather than an ordinary API one.
 
 The budget is **total elapsed time**, never an attempt count: a per-attempt
 budget multiplies out, and N attempts each allowed their own timeout stack into
@@ -50,6 +87,7 @@ policy is a :class:`RetryPolicy` you construct::
 
 from __future__ import annotations
 
+import math
 import random
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -57,11 +95,13 @@ from dataclasses import dataclass
 import httpx
 
 #: Transport failures where the request was never delivered, so the server
-#: cannot be working on it: the connection was never established, never taken
-#: from the pool, or was refused by a proxy. Retrying one of these cannot
-#: duplicate work. Checked before :data:`_POSSIBLY_IN_FLIGHT`, which some of
-#: them also match (``ConnectError`` is a ``NetworkError``, ``ConnectTimeout``
-#: a ``TimeoutException``).
+#: cannot be working on it and cannot have claimed the ``Idempotency-Key``:
+#: the connection was never established, never taken from the pool, or was
+#: refused by a proxy. Retrying one of these under the same key cannot
+#: duplicate work and cannot collide with the key's earlier use. Checked before
+#: :data:`_POSSIBLY_IN_FLIGHT`, which some of them also match
+#: (``ConnectError`` is a ``NetworkError``, ``ConnectTimeout`` a
+#: ``TimeoutException``).
 _NEVER_DELIVERED: tuple[type[BaseException], ...] = (
     httpx.ConnectError,
     httpx.ConnectTimeout,
@@ -80,23 +120,50 @@ _POSSIBLY_IN_FLIGHT: tuple[type[BaseException], ...] = (
     httpx.RemoteProtocolError,
 )
 
+#: The one 4xx another attempt can change, and only when it carries a pace.
+_TOO_MANY_REQUESTS = 429
 
-def is_retryable_status(status: int) -> bool:
-    """Whether an HTTP status is worth another attempt.
+#: Policy fields that must be real numbers for the arithmetic below to mean
+#: anything. Kept beside the fields themselves so a numeric one added later is
+#: added here too.
+_NUMERIC_FIELDS = ("max_elapsed", "initial_backoff", "backoff_factor", "max_backoff")
 
-    5xx only. A 4xx is the server's considered answer about *this* request and
-    repeating it spends money to be refused again — ``404`` (no such model),
-    ``409``, ``422`` (invalid input) and a content-policy refusal are all
-    deterministic, and none of them become true on the second ask. ``429`` is
-    excluded too: it asks for a specific ``Retry-After`` pace rather than the
-    blind backoff here, and the workflow surface already honours it separately.
 
-    A ``502``/``504`` from an intermediary is included even though the origin
-    behind it may still be generating — the response completed, so *this*
-    attempt is definitively over. What keeps that retry from being billed twice
-    is the unchanged ``Idempotency-Key``, not the status.
+def is_unknown_outcome_status(status: int) -> bool:
+    """Whether a completed response leaves this request's outcome *unknown*.
+
+    5xx, and "unknown" is the operative word rather than "transient". The
+    vendored contract keeps an ``Idempotency-Key`` claimed for a request whose
+    outcome the server cannot characterise — "an upstream timeout or 5xx where
+    the job may or may not have been created" — and rejects any later request
+    presenting a claimed key ``422`` ``idempotency_key_reuse``. That is why
+    this class sits behind :attr:`RetryPolicy.retry_possibly_in_flight` rather
+    than being retried by default: unless the deployment replays a claimed key,
+    the same-key retry cannot succeed and *replaces* the genuine 5xx with a
+    confusing key-reuse error.
+
+    A ``502``/``504`` from an intermediary belongs here for the same reason:
+    the proxy's response completed, which says nothing about whether the origin
+    behind it stopped generating.
     """
     return 500 <= status <= 599
+
+
+def retry_after_of(exc: BaseException) -> float | None:
+    """The pace the server named, in seconds, or ``None`` if it named none.
+
+    Read off whatever exception carries it — the transport parses
+    ``Retry-After`` into ``ApiError.retry_after`` for any status. A value that
+    is not a usable number of seconds is treated as absent rather than trusted
+    into the arithmetic below.
+    """
+    raw = getattr(exc, "retry_after", None)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    seconds = float(raw)
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return seconds
 
 
 @dataclass(frozen=True)
@@ -119,22 +186,38 @@ class RetryPolicy:
     #: Multiplier applied to the backoff ceiling after each attempt.
     backoff_factor: float = 2.0
     #: Ceiling the growing backoff holds at, so a long ``max_elapsed`` does not
-    #: imply an ever-lengthening final wait.
+    #: imply an ever-lengthening final wait. A ``Retry-After`` the server sent
+    #: is honoured as given and is not capped by this — the point of a named
+    #: pace is that the server knows better than the schedule here.
     max_backoff: float = 15.0
     #: Randomise each delay over ``[0, ceiling]`` ("full jitter") instead of
     #: waiting the ceiling exactly. On by default: identical clients that fail
     #: together would otherwise retry together, converting one outage into a
     #: synchronised thundering herd on the recovering server.
     jitter: bool = True
-    #: Also retry when the request's fate is unknown — no response arrived, so
-    #: the server may still be generating. Off by default: that retry is only
-    #: safe against a server that replays a repeated ``Idempotency-Key``
-    #: instead of running the request again. Turning it on usually means
-    #: raising ``max_elapsed`` as well, since one full-length client timeout on
-    #: a run can exhaust the default budget on its own.
+    #: Also retry when the request's outcome is unknown — a completed 5xx, or a
+    #: transport failure that may have delivered the request, so the server may
+    #: still be generating. Off by default, and the reason is the contract
+    #: rather than caution: every documented statement about
+    #: ``Idempotency-Key`` makes it single-use with no replay, and the spec
+    #: keeps it *claimed* across exactly this class of failure — so a same-key
+    #: retry here comes back ``422`` ``idempotency_key_reuse`` and hides the
+    #: real error. Turn it on for a deployment that replays a repeated key
+    #: instead of rejecting it — and raise ``max_elapsed`` when you do, since
+    #: one full-length client timeout on a run can spend the default budget on
+    #: its own.
     retry_possibly_in_flight: bool = False
 
     def __post_init__(self) -> None:
+        for name in _NUMERIC_FIELDS:
+            # NaN fails every ordered comparison below and infinity passes them
+            # all, so both would construct cleanly and misbehave much later: an
+            # infinite budget never reaches its deadline and retries a
+            # permanently failing server forever, a NaN backoff makes the
+            # caller's `sleep` raise `ValueError` in place of the real error,
+            # and a NaN budget silently reads as "retrying disabled".
+            if not math.isfinite(getattr(self, name)):
+                raise ValueError(f"{name} must be a finite number")
         if self.max_elapsed < 0:
             raise ValueError("max_elapsed must not be negative")
         if self.initial_backoff <= 0:
@@ -156,11 +239,23 @@ class RetryPolicy:
         actually sent, whatever layer modelled it (the protocol ``ApiError``,
         an SDK exception, a router one) — so the status decides. Everything
         else is a transport failure, decided by whether the request can still
-        be executing server-side.
+        be executing server-side. See this module's docstring for the four
+        classes and why the key's contract, not the network, sorts them.
         """
         status = getattr(exc, "http_status", None)
         if isinstance(status, int):
-            return is_retryable_status(status)
+            if status == _TOO_MANY_REQUESTS:
+                # Rejected without starting work, so the contract released the
+                # key and the same one is still spendable. Only with a pace
+                # attached: the spec's retry signal is "429 + Retry-After",
+                # and a 429 without one is not asking to be asked again.
+                return retry_after_of(exc) is not None
+            if is_unknown_outcome_status(status):
+                return self.retry_possibly_in_flight
+            # Every other 4xx is deterministic — 404 (no such model), 409, 422
+            # (invalid input), a content-policy refusal — and none of them
+            # become true on the second ask.
+            return False
         if isinstance(exc, _NEVER_DELIVERED):
             return True
         if isinstance(exc, _POSSIBLY_IN_FLIGHT):
@@ -173,11 +268,30 @@ class RetryPolicy:
         ``rng`` is injectable so the schedule can be asserted exactly; callers
         outside the tests leave it alone.
         """
-        # Clamped so a pathological policy (tiny backoff, huge budget) cannot
-        # reach an exponent that overflows the float before the cap applies.
-        exponent = min(max(attempt - 1, 0), 64)
-        ceiling = min(self.max_backoff, self.initial_backoff * self.backoff_factor**exponent)
+        ceiling = self._ceiling(max(attempt - 1, 0))
         return ceiling * rng() if self.jitter else ceiling
+
+    def _ceiling(self, exponent: int) -> float:
+        """The un-jittered delay ceiling ``exponent`` doublings in.
+
+        The comparison against ``max_backoff`` happens *before* the
+        exponentiation rather than after it. ``initial_backoff *
+        backoff_factor**exponent`` is fully evaluated before any ``min()``
+        could cap it, and CPython's float ``**`` raises ``OverflowError``
+        rather than saturating to infinity — which would escape
+        :meth:`Retrier.delay_before_retry` and replace the genuine API error
+        with an arithmetic one. Deciding in log space also means no attempt
+        count is too large to answer, where clamping the exponent instead
+        would freeze a gentle ``backoff_factor`` short of its own ceiling.
+        """
+        if self.backoff_factor == 1.0 or self.initial_backoff >= self.max_backoff:
+            return min(self.initial_backoff, self.max_backoff)
+        reaches_ceiling_at = math.log(self.max_backoff / self.initial_backoff) / math.log(
+            self.backoff_factor
+        )
+        if exponent >= reaches_ceiling_at:
+            return self.max_backoff
+        return min(self.max_backoff, self.initial_backoff * self.backoff_factor**exponent)
 
 
 #: The policy every client uses unless told otherwise.
@@ -223,19 +337,25 @@ class Retrier:
         """Seconds to sleep before retrying after ``exc``, or ``None`` to give up.
 
         ``None`` means the caller re-raises: either the failure is not
-        retryable, or the next attempt would start after the deadline. The
-        deadline is checked against the *end* of the sleep, so no attempt ever
-        begins outside the budget — the bound holds even when the backoff is
-        long relative to what is left.
+        retryable, or the budget is already spent. A delay that would overshoot
+        the deadline is *clamped* to what is left rather than treated as a
+        refusal — with full jitter one unlucky draw would otherwise end a call
+        that still had seconds of budget, making identical calls take a
+        randomly varying number of attempts. ``client.py::_retry_delay`` bounds
+        the workflow surface's 429 wait the same way. So ``max_elapsed`` is
+        when the last attempt may *start*, inclusive.
         """
         failed_at = self._now()
         self._attempts += 1
         if not self._policy.enabled or not self._policy.should_retry(exc):
             return None
-        delay = self._policy.backoff(self._attempts, rng=self._rng)
-        if failed_at + delay >= self._deadline:
+        remaining = self._deadline - failed_at
+        if remaining <= 0:
             return None
-        return delay
+        # A pace the server named beats the schedule guessed here.
+        named = retry_after_of(exc)
+        delay = named if named is not None else self._policy.backoff(self._attempts, rng=self._rng)
+        return min(delay, remaining)
 
 
 __all__ = [
@@ -243,5 +363,6 @@ __all__ = [
     "NO_RETRY",
     "Retrier",
     "RetryPolicy",
-    "is_retryable_status",
+    "is_unknown_outcome_status",
+    "retry_after_of",
 ]

--- a/src/comfy_sdk/retry.py
+++ b/src/comfy_sdk/retry.py
@@ -1,0 +1,247 @@
+"""Bounded, idempotent client-side retry for ``client.models.run``.
+
+A model run holds one HTTP connection open for as long as the generation takes
+— minutes, for a provider the platform submits to and polls internally. That
+shape is what makes a naive retry expensive rather than merely noisy: the
+client gives up on a connection, retries, and a *second* generation is started
+and billed for one logical request.
+
+Two properties of this module exist to make that impossible.
+
+**Every attempt of one logical call sends the same ``Idempotency-Key``.** The
+key is minted once, before the first attempt, and reused verbatim on each
+retry; a *new* call mints a new key. That is what lets a server recognise a
+retry as the same request rather than a second order. The key is sent
+unconditionally — there is no configuration that turns it off — because a retry
+without it is exactly the double-charge above.
+
+**A retry never begins while the original attempt might still be running on the
+server.** The client cannot observe the server's side of an aborted request, so
+this is enforced structurally rather than by guessing:
+
+1. Attempts are strictly sequential. One attempt's connection is closed and its
+   backoff has elapsed before the next is opened; two attempts of one logical
+   call are never in flight at once.
+2. The retry deadline never interrupts an attempt. It is checked only *between*
+   attempts, so the SDK never abandons a request that is merely slow — the
+   per-attempt ``timeout`` is the only thing that ends an attempt, and on a run
+   that is the long, generation-sized timeout rather than an ordinary API one.
+3. A failure that leaves the request's fate *unknown* — no response arrived, so
+   the server may still be generating — is not retried by default. Only
+   failures where this attempt provably finished are: a completed 5xx response,
+   or a connect-phase failure that never delivered the request at all. Opting
+   in is :attr:`RetryPolicy.retry_possibly_in_flight`, and it is safe once the
+   server replays a repeated ``Idempotency-Key`` rather than re-running it.
+
+The budget is **total elapsed time**, never an attempt count: a per-attempt
+budget multiplies out, and N attempts each allowed their own timeout stack into
+a wait far longer than anything anybody chose. ``max_elapsed`` bounds when the
+*last* attempt may start, so the worst case is that bound plus one per-attempt
+timeout, and the number of attempts falls out of the backoff schedule.
+
+Retry is on by default. ``Comfy(retry=NO_RETRY)`` turns it off; any other
+policy is a :class:`RetryPolicy` you construct::
+
+    from comfy_sdk import Comfy, NO_RETRY, RetryPolicy
+
+    Comfy(retry=NO_RETRY)                              # exactly one attempt
+    Comfy(retry=RetryPolicy(max_elapsed=300.0))        # keep trying for 5 min
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import httpx
+
+#: Transport failures where the request was never delivered, so the server
+#: cannot be working on it: the connection was never established, never taken
+#: from the pool, or was refused by a proxy. Retrying one of these cannot
+#: duplicate work. Checked before :data:`_POSSIBLY_IN_FLIGHT`, which some of
+#: them also match (``ConnectError`` is a ``NetworkError``, ``ConnectTimeout``
+#: a ``TimeoutException``).
+_NEVER_DELIVERED: tuple[type[BaseException], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+    httpx.ProxyError,
+)
+
+#: Transport failures that leave the request's fate unknown — it may have been
+#: delivered in full and still be executing server-side. A read timeout on a
+#: run is the important member: the generation-sized client timeout expired
+#: with no answer, which is precisely the case where the server is most likely
+#: still generating.
+_POSSIBLY_IN_FLIGHT: tuple[type[BaseException], ...] = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+)
+
+
+def is_retryable_status(status: int) -> bool:
+    """Whether an HTTP status is worth another attempt.
+
+    5xx only. A 4xx is the server's considered answer about *this* request and
+    repeating it spends money to be refused again — ``404`` (no such model),
+    ``409``, ``422`` (invalid input) and a content-policy refusal are all
+    deterministic, and none of them become true on the second ask. ``429`` is
+    excluded too: it asks for a specific ``Retry-After`` pace rather than the
+    blind backoff here, and the workflow surface already honours it separately.
+
+    A ``502``/``504`` from an intermediary is included even though the origin
+    behind it may still be generating — the response completed, so *this*
+    attempt is definitively over. What keeps that retry from being billed twice
+    is the unchanged ``Idempotency-Key``, not the status.
+    """
+    return 500 <= status <= 599
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """When and how often to retry one logical call.
+
+    Immutable, so a policy can be shared by every call on a client without one
+    call's state leaking into another's. Bounds are wall-clock, not attempt
+    counts — see this module's docstring for why.
+    """
+
+    #: Seconds from the first attempt after which no *new* attempt is started.
+    #: An attempt already running is never interrupted by it, so the worst-case
+    #: wall clock for a call is this plus one per-attempt ``timeout``. Zero
+    #: disables retrying entirely (see :data:`NO_RETRY`).
+    max_elapsed: float = 60.0
+    #: Ceiling on the delay before the first retry. With ``jitter`` on — the
+    #: default — the actual delay is drawn from ``[0, this]``.
+    initial_backoff: float = 0.5
+    #: Multiplier applied to the backoff ceiling after each attempt.
+    backoff_factor: float = 2.0
+    #: Ceiling the growing backoff holds at, so a long ``max_elapsed`` does not
+    #: imply an ever-lengthening final wait.
+    max_backoff: float = 15.0
+    #: Randomise each delay over ``[0, ceiling]`` ("full jitter") instead of
+    #: waiting the ceiling exactly. On by default: identical clients that fail
+    #: together would otherwise retry together, converting one outage into a
+    #: synchronised thundering herd on the recovering server.
+    jitter: bool = True
+    #: Also retry when the request's fate is unknown — no response arrived, so
+    #: the server may still be generating. Off by default: that retry is only
+    #: safe against a server that replays a repeated ``Idempotency-Key``
+    #: instead of running the request again. Turning it on usually means
+    #: raising ``max_elapsed`` as well, since one full-length client timeout on
+    #: a run can exhaust the default budget on its own.
+    retry_possibly_in_flight: bool = False
+
+    def __post_init__(self) -> None:
+        if self.max_elapsed < 0:
+            raise ValueError("max_elapsed must not be negative")
+        if self.initial_backoff <= 0:
+            raise ValueError("initial_backoff must be positive")
+        if self.backoff_factor < 1:
+            raise ValueError("backoff_factor must be >= 1")
+        if self.max_backoff < self.initial_backoff:
+            raise ValueError("max_backoff must be >= initial_backoff")
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this policy ever retries."""
+        return self.max_elapsed > 0
+
+    def should_retry(self, exc: BaseException) -> bool:
+        """Whether ``exc`` is a condition another attempt could survive.
+
+        An exception carrying an ``http_status`` is a response the server
+        actually sent, whatever layer modelled it (the protocol ``ApiError``,
+        an SDK exception, a router one) — so the status decides. Everything
+        else is a transport failure, decided by whether the request can still
+        be executing server-side.
+        """
+        status = getattr(exc, "http_status", None)
+        if isinstance(status, int):
+            return is_retryable_status(status)
+        if isinstance(exc, _NEVER_DELIVERED):
+            return True
+        if isinstance(exc, _POSSIBLY_IN_FLIGHT):
+            return self.retry_possibly_in_flight
+        return False
+
+    def backoff(self, attempt: int, *, rng: Callable[[], float] = random.random) -> float:
+        """Seconds to wait before retry number ``attempt`` (1 is the first).
+
+        ``rng`` is injectable so the schedule can be asserted exactly; callers
+        outside the tests leave it alone.
+        """
+        # Clamped so a pathological policy (tiny backoff, huge budget) cannot
+        # reach an exponent that overflows the float before the cap applies.
+        exponent = min(max(attempt - 1, 0), 64)
+        ceiling = min(self.max_backoff, self.initial_backoff * self.backoff_factor**exponent)
+        return ceiling * rng() if self.jitter else ceiling
+
+
+#: The policy every client uses unless told otherwise.
+DEFAULT_RETRY = RetryPolicy()
+
+#: Retrying turned off: one logical call is exactly one attempt. Pass it as
+#: ``Comfy(retry=NO_RETRY)``. The ``Idempotency-Key`` is still sent — it is not
+#: part of the retry policy, and a caller who retries by hand needs it.
+NO_RETRY = RetryPolicy(max_elapsed=0.0)
+
+
+class Retrier:
+    """One logical call's place in a :class:`RetryPolicy`.
+
+    Sans-IO: it decides *whether* and *how long* to wait, and the sync and
+    async layers do the waiting (``time.sleep`` / ``asyncio.sleep``). Single
+    use — construct one per logical call, immediately before the first
+    attempt, since the budget is measured from its construction.
+    """
+
+    def __init__(
+        self,
+        policy: RetryPolicy,
+        *,
+        now: Callable[[], float],
+        rng: Callable[[], float] = random.random,
+    ) -> None:
+        self._policy = policy
+        self._now = now
+        self._rng = rng
+        self._attempts = 0
+        # The whole call's budget, fixed here so every later decision measures
+        # against one origin — elapsed time across all attempts, not time
+        # granted afresh to each of them.
+        self._deadline = now() + policy.max_elapsed
+
+    @property
+    def attempts(self) -> int:
+        """Attempts that have failed so far."""
+        return self._attempts
+
+    def delay_before_retry(self, exc: BaseException) -> float | None:
+        """Seconds to sleep before retrying after ``exc``, or ``None`` to give up.
+
+        ``None`` means the caller re-raises: either the failure is not
+        retryable, or the next attempt would start after the deadline. The
+        deadline is checked against the *end* of the sleep, so no attempt ever
+        begins outside the budget — the bound holds even when the backoff is
+        long relative to what is left.
+        """
+        failed_at = self._now()
+        self._attempts += 1
+        if not self._policy.enabled or not self._policy.should_retry(exc):
+            return None
+        delay = self._policy.backoff(self._attempts, rng=self._rng)
+        if failed_at + delay >= self._deadline:
+            return None
+        return delay
+
+
+__all__ = [
+    "DEFAULT_RETRY",
+    "NO_RETRY",
+    "Retrier",
+    "RetryPolicy",
+    "is_retryable_status",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,13 @@ class ServerState:
     model_run_delay: float = 0.0
     # (status, code) answered instead of the result.
     model_run_error: tuple[int, str] | None = None
+    # POST /models/run fails this many times before serving the result — the
+    # transient-failure-then-success path a retry policy exists for. Decremented
+    # per request, and checked *before* `model_run_error`, which is the
+    # permanent-failure knob.
+    model_run_fail_times: int = 0
+    # (status, code) each of those transient failures answers with.
+    model_run_transient_error: tuple[int, str] = (503, "internal_error")
     # Status code for a successful run (201 exercises the created-shaped path).
     model_run_status: int = 200
 
@@ -433,6 +440,11 @@ def _make_handler(state: ServerState):
             if state.model_run_delay:
                 # The server holding the connection while it polls upstream.
                 time.sleep(state.model_run_delay)
+            if state.model_run_fail_times > 0:
+                state.model_run_fail_times -= 1
+                status, code = state.model_run_transient_error
+                self._err(status, code, f"transient model run error {code}")
+                return
             if state.model_run_error is not None:
                 status, code = state.model_run_error
                 self._err(status, code, f"model run error {code}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,16 @@ class ServerState:
     model_run_transient_error: tuple[int, str] = (503, "internal_error")
     # Status code for a successful run (201 exercises the created-shaped path).
     model_run_status: int = 200
+    # Model the deployment `retry_possibly_in_flight` exists for: one that
+    # *replays* a repeated Idempotency-Key rather than rejecting it, so a key
+    # is released rather than claimed when a request fails 5xx. Default False
+    # is the vendored contract (reject-on-duplicate, no replay), under which a
+    # same-key retry after a 5xx can only come back 422.
+    model_run_replays_idempotency_key: bool = False
+    # Seconds sent as Retry-After alongside `model_run_error`, when that error
+    # is the 429 the policy is allowed to pace itself against. `None` sends no
+    # header at all, which is the 429 the policy must *not* retry.
+    model_run_retry_after: str | None = None
 
     # --- counters the tests assert on ---
     upload_count: int = 0
@@ -137,6 +147,10 @@ class ServerState:
     # Every Idempotency-Key seen on POST /models/run, in arrival order (`None`
     # records a run that arrived without the header at all).
     model_run_idempotency_keys: list[str | None] = field(default_factory=list)
+    # Keys POST /models/run has *claimed*, so a reuse can be rejected exactly
+    # as POST /jobs rejects one. Kept apart from `idempotency` only so a model
+    # test cannot perturb a workflow test's bookkeeping.
+    model_run_idempotency: dict[str, str] = field(default_factory=dict)
 
 
 def _asset_json(asset_id: str, hash_: str, created_new: bool, size: int) -> dict:
@@ -436,19 +450,48 @@ def _make_handler(state: ServerState):
         def _post_model_run(self) -> None:
             state.model_run_count += 1
             state.last_model_run_body = json.loads(self._read_body() or b"{}")
-            state.model_run_idempotency_keys.append(self.headers.get("Idempotency-Key"))
+            key = self.headers.get("Idempotency-Key")
+            state.model_run_idempotency_keys.append(key)
+
+            # The same reject-on-duplicate rule `_post_jobs` implements, for
+            # the same reason: a stub more permissive than the contract would
+            # let a retry design that the real server rejects pass its tests.
+            if key and key in state.model_run_idempotency:
+                self._err(422, "idempotency_key_reuse", "Idempotency-Key already used")
+                return
+
             if state.model_run_delay:
                 # The server holding the connection while it polls upstream.
                 time.sleep(state.model_run_delay)
+
+            def claim_if_outcome_unknown(status: int) -> None:
+                # The contract releases a key for a request that definitively
+                # failed without starting work (a 4xx) and keeps it claimed
+                # when the outcome is unknown (a 5xx). A replaying deployment
+                # is the exception, and is what the opt-in is for.
+                if key and status >= 500 and not state.model_run_replays_idempotency_key:
+                    state.model_run_idempotency[key] = "claimed"
+
+            def fail(status: int, code: str, message: str) -> None:
+                claim_if_outcome_unknown(status)
+                headers = (
+                    {"Retry-After": state.model_run_retry_after}
+                    if state.model_run_retry_after is not None
+                    else None
+                )
+                self._json(status, {"error": {"code": code, "message": message}}, headers=headers)
+
             if state.model_run_fail_times > 0:
                 state.model_run_fail_times -= 1
                 status, code = state.model_run_transient_error
-                self._err(status, code, f"transient model run error {code}")
+                fail(status, code, f"transient model run error {code}")
                 return
             if state.model_run_error is not None:
                 status, code = state.model_run_error
-                self._err(status, code, f"model run error {code}")
+                fail(status, code, f"model run error {code}")
                 return
+            if key:
+                state.model_run_idempotency[key] = "done"
             self._json(state.model_run_status, state.model_run_result)
 
         def _post_jobs(self) -> None:

--- a/tests/test_models_run.py
+++ b/tests/test_models_run.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from comfy_low.transport import MODEL_RUN_TIMEOUT, AsyncComfyLow, ComfyLow, model_run_request
-from comfy_sdk import AsyncComfy, Comfy
+from comfy_sdk import NO_RETRY, AsyncComfy, Comfy
 from comfy_sdk.exceptions import ComfyError, NotFound, Unauthorized
 from comfy_sdk.models import AsyncModels, Models
 
@@ -233,8 +233,12 @@ async def test_a_failing_async_run_raises_the_sdk_exception(server) -> None:
 
 
 def test_an_unmapped_failure_still_lands_as_a_comfy_error(server) -> None:
+    # `NO_RETRY` because a 503 is retryable: under the default policy this
+    # would spend the whole retry budget re-asking a permanently-failing stub
+    # before raising. What is under test here is the mapping, not the policy —
+    # tests/test_models_run_retry.py covers the retrying half.
     server.state.model_run_error = (503, "model_unavailable")
-    with Comfy() as client:
+    with Comfy(retry=NO_RETRY) as client:
         with pytest.raises(ComfyError) as excinfo:
             client.models.run(MODEL, ARGS)
     assert excinfo.value.code == "model_unavailable"

--- a/tests/test_models_run_retry.py
+++ b/tests/test_models_run_retry.py
@@ -1,0 +1,438 @@
+"""Retrying a model run without paying for it twice.
+
+The assertion this file exists for is
+``test_every_attempt_of_one_call_sends_the_same_idempotency_key``: a retry that
+mints a fresh key is indistinguishable, server-side, from a second order, and
+on a surface where one call is a billed generation that is the difference
+between a retry and a double charge. Everything else here is the policy that
+decides *whether* to make that second attempt — 5xx and connect-phase failures
+yes, a deterministic 4xx refusal no, a request that may still be running
+server-side not unless asked — plus the elapsed-time bound that stops the
+attempts stacking up.
+
+The stub server in ``conftest.py`` drives the wire half (``model_run_fail_times``
+for transient failure, ``model_run_error`` for a permanent one); the schedule
+and deadline arithmetic is asserted directly against
+:class:`~comfy_sdk.retry.RetryPolicy` and :class:`~comfy_sdk.retry.Retrier`,
+where a fake clock makes it exact instead of timing-dependent.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from comfy_sdk import DEFAULT_RETRY, NO_RETRY, AsyncComfy, Comfy, RetryPolicy
+from comfy_sdk.exceptions import ComfyError
+from comfy_sdk.retry import Retrier, is_retryable_status
+from comfy_sdk.router_exceptions import ContentPolicyViolation, InternalError
+
+
+class _FakeClock:
+    """A monotonic clock the test moves by hand."""
+
+    def __init__(self) -> None:
+        self._t = 1000.0
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+MODEL = "acme/flux/dev"
+ARGS = {"prompt": "a cat", "steps": 4}
+
+#: Retries the suite can afford to sit through: the schedule is asserted
+#: against a fake clock elsewhere, so what these tests need from the real one
+#: is only that the attempts happen at all.
+FAST = RetryPolicy(max_elapsed=5.0, initial_backoff=0.01, max_backoff=0.02)
+
+
+# --- the same key on every attempt of one call ---------------------------
+
+
+def test_every_attempt_of_one_call_sends_the_same_idempotency_key(server) -> None:
+    # The assertion that prevents the double charge: three attempts, one key.
+    # A retry carrying a fresh key would read server-side as three separate
+    # generations to run and bill.
+    server.state.model_run_fail_times = 2
+    with Comfy(retry=FAST) as client:
+        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
+    keys = server.state.model_run_idempotency_keys
+    assert server.state.model_run_count == 3
+    assert len(keys) == 3
+    assert all(k for k in keys)
+    assert len(set(keys)) == 1
+
+
+async def test_every_attempt_of_one_async_call_sends_the_same_key(server) -> None:
+    server.state.model_run_fail_times = 2
+    async with AsyncComfy(retry=FAST) as client:
+        assert await client.models.run(MODEL, ARGS) == server.state.model_run_result
+    keys = server.state.model_run_idempotency_keys
+    assert len(keys) == 3
+    assert len(set(keys)) == 1
+
+
+def test_a_second_call_is_a_new_key_even_though_both_retried(server) -> None:
+    # The other half of the contract: a key is per logical call, not per
+    # client and not per process. Two calls that each retried must not share
+    # one — that would make the second call a replay of the first.
+    server.state.model_run_fail_times = 1
+    with Comfy(retry=FAST) as client:
+        client.models.run(MODEL, ARGS)
+        server.state.model_run_fail_times = 1
+        client.models.run(MODEL, ARGS)
+    keys = server.state.model_run_idempotency_keys
+    first_call, second_call = keys[:2], keys[2:]
+    assert len(set(first_call)) == 1
+    assert len(set(second_call)) == 1
+    assert set(first_call) != set(second_call)
+
+
+async def test_a_second_async_call_is_a_new_key(server) -> None:
+    async with AsyncComfy(retry=FAST) as client:
+        await client.models.run(MODEL, ARGS)
+        await client.models.run(MODEL, ARGS)
+    first, second = server.state.model_run_idempotency_keys
+    assert first != second
+
+
+def test_an_explicit_key_is_reused_across_retries_verbatim(server) -> None:
+    server.state.model_run_fail_times = 2
+    with Comfy(retry=FAST) as client:
+        client.models.run(MODEL, ARGS, idempotency_key="caller-chosen-07")
+    assert server.state.model_run_idempotency_keys == ["caller-chosen-07"] * 3
+
+
+# --- what gets retried ---------------------------------------------------
+
+
+def test_retry_is_on_by_default(server) -> None:
+    # No `retry=` argument anywhere: a transient failure is survived out of
+    # the box, which is the point of the default being on.
+    server.state.model_run_fail_times = 1
+    with Comfy() as client:
+        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
+    assert server.state.model_run_count == 2
+
+
+def test_the_default_policy_retries_and_bounds_by_elapsed_time() -> None:
+    assert DEFAULT_RETRY.enabled
+    assert DEFAULT_RETRY.max_elapsed > 0
+    assert DEFAULT_RETRY.jitter
+    # Off by default: retrying a request that may still be generating is only
+    # safe against a server that replays the key rather than re-running it.
+    assert not DEFAULT_RETRY.retry_possibly_in_flight
+
+
+def test_retry_can_be_disabled(server) -> None:
+    server.state.model_run_fail_times = 1
+    with Comfy(retry=NO_RETRY) as client:
+        with pytest.raises(ComfyError):
+            client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+
+
+async def test_retry_can_be_disabled_on_the_async_client(server) -> None:
+    server.state.model_run_fail_times = 1
+    async with AsyncComfy(retry=NO_RETRY) as client:
+        with pytest.raises(ComfyError):
+            await client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+
+
+def test_the_policy_is_readable_off_the_namespace(server) -> None:
+    with Comfy(retry=NO_RETRY) as client:
+        assert client.models.retry is NO_RETRY
+    with Comfy() as client:
+        assert client.models.retry is DEFAULT_RETRY
+
+
+@pytest.mark.parametrize(
+    "status,code",
+    [
+        (400, "content_policy_violation"),
+        (404, "not_found"),
+        (409, "hash_mismatch"),
+        (422, "invalid_workflow"),
+        (401, "unauthorized"),
+        (402, "insufficient_credits"),
+    ],
+    ids=lambda v: str(v),
+)
+def test_a_deterministic_refusal_is_never_retried(server, status: int, code: str) -> None:
+    # Asking again cannot change any of these answers, and on a billed surface
+    # a retry of a refusal spends money to be refused again.
+    server.state.model_run_error = (status, code)
+    with Comfy(retry=FAST) as client:
+        with pytest.raises(ComfyError):
+            client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+
+
+def test_a_429_is_not_retried_by_this_policy(server) -> None:
+    # Deliberate: a 429 names its own pace in `Retry-After`, and honouring that
+    # is a different mechanism from the blind backoff here. Blindly retrying it
+    # would ignore the pace the server asked for.
+    server.state.model_run_error = (429, "queue_full")
+    with Comfy(retry=FAST) as client:
+        with pytest.raises(ComfyError):
+            client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+
+
+async def test_a_deterministic_refusal_is_never_retried_on_the_async_client(server) -> None:
+    server.state.model_run_error = (422, "invalid_workflow")
+    async with AsyncComfy(retry=FAST) as client:
+        with pytest.raises(ComfyError):
+            await client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_a_5xx_is_retried(server, status: int) -> None:
+    server.state.model_run_transient_error = (status, "internal_error")
+    server.state.model_run_fail_times = 1
+    with Comfy(retry=FAST) as client:
+        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
+    assert server.state.model_run_count == 2
+
+
+def test_a_permanent_5xx_eventually_surfaces_as_the_sdk_error(server) -> None:
+    server.state.model_run_error = (500, "internal_error")
+    policy = RetryPolicy(max_elapsed=0.2, initial_backoff=0.01, max_backoff=0.02)
+    with Comfy(retry=policy) as client:
+        with pytest.raises(ComfyError) as excinfo:
+            client.models.run(MODEL, ARGS)
+    assert excinfo.value.http_status == 500
+    # It gave up rather than looping forever, and it did try more than once.
+    assert server.state.model_run_count > 1
+    assert len(set(server.state.model_run_idempotency_keys)) == 1
+
+
+# --- the long client timeout: a retry must not race the original ---------
+
+
+def test_a_client_timeout_is_not_retried_by_default(server) -> None:
+    # A run holds the connection while the server generates, so a client-side
+    # timeout means "no answer yet", not "it did not happen". The server may
+    # still be generating, so the default policy does not start a second one.
+    server.state.model_run_delay = 1.0
+    with Comfy(retry=FAST) as client:
+        with pytest.raises(httpx.TimeoutException):
+            client.models.run(MODEL, ARGS, timeout=0.15)
+    assert server.state.model_run_count == 1
+
+
+async def test_an_async_client_timeout_is_not_retried_by_default(server) -> None:
+    server.state.model_run_delay = 1.0
+    async with AsyncComfy(retry=FAST) as client:
+        with pytest.raises(httpx.TimeoutException):
+            await client.models.run(MODEL, ARGS, timeout=0.15)
+    assert server.state.model_run_count == 1
+
+
+def test_opting_in_retries_a_client_timeout_under_the_one_key(server) -> None:
+    # The opt-in for a server that replays a repeated key. Even here the key is
+    # unchanged, so the second attempt is the same request, not a second order.
+    server.state.model_run_delay = 1.5
+    policy = RetryPolicy(
+        max_elapsed=1.0,
+        initial_backoff=0.01,
+        max_backoff=0.02,
+        retry_possibly_in_flight=True,
+    )
+    with Comfy(retry=policy) as client:
+        with pytest.raises(httpx.TimeoutException):
+            client.models.run(MODEL, ARGS, timeout=0.15)
+    assert server.state.model_run_count >= 2
+    assert len(set(server.state.model_run_idempotency_keys)) == 1
+
+
+def test_the_retry_deadline_never_interrupts_an_attempt(server) -> None:
+    # The deadline is checked between attempts only. An attempt that outlives
+    # the whole retry budget still runs to its own timeout and returns — the
+    # SDK never abandons a request that is merely slow, which is what would
+    # leave a generation running with nobody waiting for it.
+    server.state.model_run_delay = 0.4
+    policy = RetryPolicy(max_elapsed=0.05, initial_backoff=0.01, max_backoff=0.02)
+    with Comfy(retry=policy) as client:
+        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
+    assert server.state.model_run_count == 1
+
+
+# --- bounded by elapsed time, not by attempt count -----------------------
+
+
+def test_retries_stop_at_the_elapsed_budget_not_at_an_attempt_count(server) -> None:
+    # A per-attempt budget multiplies: N attempts each granted their own wait
+    # stack into a total nobody chose. This bound is wall-clock across the
+    # whole call, so however cheap an attempt is, the call still ends.
+    server.state.model_run_error = (503, "internal_error")
+    policy = RetryPolicy(max_elapsed=0.3, initial_backoff=0.01, max_backoff=0.02)
+    started = time.monotonic()
+    with Comfy(retry=policy) as client:
+        with pytest.raises(ComfyError):
+            client.models.run(MODEL, ARGS)
+    elapsed = time.monotonic() - started
+    # Generous upper bound: what matters is that it is bounded by the budget
+    # rather than by however many cheap attempts fit in it.
+    assert elapsed < 5.0
+    assert server.state.model_run_count > 1
+
+
+def test_the_deadline_is_measured_from_the_first_attempt() -> None:
+    clock = _FakeClock()
+    policy = RetryPolicy(max_elapsed=10.0, initial_backoff=1.0, max_backoff=1.0, jitter=False)
+    retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
+    failure = InternalError("boom", http_status=500)
+
+    # Nine one-second waits fit inside the ten-second budget...
+    for _ in range(9):
+        delay = retrier.delay_before_retry(failure)
+        assert delay == 1.0
+        clock.advance(delay)
+    # ...and the tenth would start an attempt at the deadline, so it does not.
+    assert retrier.delay_before_retry(failure) is None
+    assert retrier.attempts == 10
+
+
+def test_a_slow_attempt_spends_the_budget_it_actually_used() -> None:
+    # The bound is elapsed time, so one attempt that takes most of the budget
+    # leaves no room for another — however few attempts have been made.
+    clock = _FakeClock()
+    policy = RetryPolicy(max_elapsed=10.0, initial_backoff=1.0, max_backoff=1.0, jitter=False)
+    retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
+    clock.advance(9.5)
+    assert retrier.delay_before_retry(InternalError("boom", http_status=500)) is None
+
+
+def test_a_disabled_policy_never_yields_a_delay() -> None:
+    retrier = Retrier(NO_RETRY, now=_FakeClock())
+    assert retrier.delay_before_retry(InternalError("boom", http_status=500)) is None
+
+
+# --- backoff and jitter --------------------------------------------------
+
+
+def test_backoff_grows_and_holds_at_the_ceiling() -> None:
+    policy = RetryPolicy(initial_backoff=1.0, backoff_factor=2.0, max_backoff=8.0, jitter=False)
+    schedule = [policy.backoff(n) for n in range(1, 7)]
+    assert schedule == [1.0, 2.0, 4.0, 8.0, 8.0, 8.0]
+
+
+def test_backoff_cannot_overflow_on_a_pathological_attempt_count() -> None:
+    policy = RetryPolicy(initial_backoff=1.0, backoff_factor=2.0, max_backoff=8.0, jitter=False)
+    assert policy.backoff(100_000) == 8.0
+
+
+def test_jitter_spreads_each_delay_below_its_ceiling() -> None:
+    # Full jitter: identical clients that failed together must not come back
+    # together and re-flatten a server that is recovering.
+    policy = RetryPolicy(initial_backoff=1.0, backoff_factor=2.0, max_backoff=8.0)
+    delays = [policy.backoff(3) for _ in range(200)]
+    ceiling = 4.0
+    assert all(0.0 <= d <= ceiling for d in delays)
+    assert len(set(delays)) > 1
+    assert min(delays) < ceiling / 2 < max(delays)
+
+
+def test_jitter_can_be_turned_off_for_a_deterministic_schedule() -> None:
+    policy = RetryPolicy(initial_backoff=1.0, backoff_factor=2.0, max_backoff=8.0, jitter=False)
+    assert len({policy.backoff(2) for _ in range(50)}) == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_elapsed": -1.0},
+        {"initial_backoff": 0.0},
+        {"initial_backoff": -1.0},
+        {"backoff_factor": 0.5},
+        {"max_backoff": 0.1},
+    ],
+    ids=["negative-budget", "zero-backoff", "negative-backoff", "shrinking", "ceiling-below-floor"],
+)
+def test_an_incoherent_policy_is_rejected_at_construction(kwargs: dict) -> None:
+    with pytest.raises(ValueError):
+        RetryPolicy(**kwargs)
+
+
+def test_a_policy_is_immutable() -> None:
+    # Shared by every call on a client, so one call cannot rewrite another's.
+    with pytest.raises(AttributeError):
+        DEFAULT_RETRY.max_elapsed = 1.0
+
+
+# --- classification ------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [500, 501, 502, 503, 504, 599])
+def test_5xx_is_retryable(status: int) -> None:
+    assert is_retryable_status(status)
+
+
+@pytest.mark.parametrize("status", [200, 400, 401, 402, 403, 404, 409, 422, 429, 499])
+def test_everything_below_500_is_not(status: int) -> None:
+    assert not is_retryable_status(status)
+
+
+def test_a_typed_router_refusal_is_classified_by_its_status() -> None:
+    # The classifier reads `http_status` off whatever exception carries it, so
+    # a typed router error is judged the same way as the protocol error the
+    # model surface raises today.
+    assert not DEFAULT_RETRY.should_retry(ContentPolicyViolation("refused", http_status=400))
+    assert DEFAULT_RETRY.should_retry(InternalError("boom", http_status=500))
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("refused"),
+        httpx.ConnectTimeout("too slow to connect"),
+        httpx.PoolTimeout("no connection free"),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_a_connect_phase_failure_is_retryable(exc: Exception) -> None:
+    # The request was never delivered, so there is nothing running server-side
+    # for a retry to duplicate.
+    assert DEFAULT_RETRY.should_retry(exc)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ReadTimeout("no answer"),
+        httpx.ReadError("connection dropped"),
+        httpx.WriteError("connection dropped"),
+        httpx.RemoteProtocolError("truncated"),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_a_possibly_in_flight_failure_needs_the_opt_in(exc: Exception) -> None:
+    assert not DEFAULT_RETRY.should_retry(exc)
+    opted_in = RetryPolicy(retry_possibly_in_flight=True)
+    assert opted_in.should_retry(exc)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.LocalProtocolError("the client built a bad request"),
+        httpx.UnsupportedProtocol("no such scheme"),
+        ValueError("not a transport failure at all"),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_a_local_failure_is_never_retryable(exc: Exception) -> None:
+    # A bug on this side of the wire does not become correct on the second try,
+    # and retrying it hides it.
+    opted_in = RetryPolicy(retry_possibly_in_flight=True)
+    assert not DEFAULT_RETRY.should_retry(exc)
+    assert not opted_in.should_retry(exc)

--- a/tests/test_models_run_retry.py
+++ b/tests/test_models_run_retry.py
@@ -4,14 +4,24 @@ The assertion this file exists for is
 ``test_every_attempt_of_one_call_sends_the_same_idempotency_key``: a retry that
 mints a fresh key is indistinguishable, server-side, from a second order, and
 on a surface where one call is a billed generation that is the difference
-between a retry and a double charge. Everything else here is the policy that
-decides *whether* to make that second attempt — 5xx and connect-phase failures
-yes, a deterministic 4xx refusal no, a request that may still be running
-server-side not unless asked — plus the elapsed-time bound that stops the
-attempts stacking up.
+between a retry and a double charge.
 
-The stub server in ``conftest.py`` drives the wire half (``model_run_fail_times``
-for transient failure, ``model_run_error`` for a permanent one); the schedule
+Everything else here is the policy that decides *whether* to make that second
+attempt, and the thing that decides it is the key's own contract rather than a
+guess about the network. ``spec/openapi.yaml`` makes ``Idempotency-Key``
+single-use, reject-on-duplicate, with no response replay, and says which
+failures release the key (a definitive reject that started no work) and which
+keep it claimed (a 5xx or upstream timeout, where the outcome is unknown). So
+the default policy retries only what the one key survives — a connect-phase
+failure, and a ``429`` that names its own ``Retry-After`` — and everything in
+the unknown-outcome class sits behind ``retry_possibly_in_flight``, for the
+deployment that replays a repeated key instead of rejecting it.
+
+The stub server in ``conftest.py`` drives the wire half and now enforces that
+same reject-on-duplicate rule (``model_run_replays_idempotency_key`` switches
+it to the replaying deployment), so a retry design the real server would reject
+cannot pass here. The never-delivered class is asserted against ``_FlakyLow``
+instead: a stub HTTP server that is up cannot refuse a connection. The schedule
 and deadline arithmetic is asserted directly against
 :class:`~comfy_sdk.retry.RetryPolicy` and :class:`~comfy_sdk.retry.Retrier`,
 where a fake clock makes it exact instead of timing-dependent.
@@ -20,13 +30,16 @@ where a fake clock makes it exact instead of timing-dependent.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
+from typing import Any, cast
 
 import httpx
 import pytest
 
 from comfy_sdk import DEFAULT_RETRY, NO_RETRY, AsyncComfy, Comfy, RetryPolicy
-from comfy_sdk.exceptions import ComfyError
-from comfy_sdk.retry import Retrier, is_retryable_status
+from comfy_sdk.exceptions import ComfyError, IdempotencyKeyReuse
+from comfy_sdk.models import AsyncModels, Models
+from comfy_sdk.retry import Retrier, is_unknown_outcome_status, retry_after_of
 from comfy_sdk.router_exceptions import ContentPolicyViolation, InternalError
 
 
@@ -43,6 +56,53 @@ class _FakeClock:
         self._t += seconds
 
 
+class _FlakyLow:
+    """A transport whose first ``fail_times`` attempts never reach the server.
+
+    The default policy's retry surface is the never-delivered class — the one
+    place a repeated ``Idempotency-Key`` is provably still spendable, because
+    the request never got far enough for the server to claim it. A stub HTTP
+    server that is listening cannot produce that failure, so the one-key
+    contract is asserted against a transport that can.
+    """
+
+    def __init__(self, fail_times: int = 0) -> None:
+        self.fail_times = fail_times
+        self.keys: list[str | None] = []
+        self.payloads: list[dict[str, Any]] = []
+        self.result: dict[str, Any] = {"images": [{"url": "http://example.invalid/x.png"}]}
+
+    def _attempt(self, arguments: Mapping[str, Any], key: str | None) -> dict[str, Any]:
+        self.keys.append(key)
+        self.payloads.append(dict(arguments))
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise httpx.ConnectError("connection refused")
+        return self.result
+
+    def post_model_run(
+        self,
+        model: str,
+        arguments: Mapping[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        timeout: Any = None,
+    ) -> dict[str, Any]:
+        return self._attempt(arguments, idempotency_key)
+
+
+class _AsyncFlakyLow(_FlakyLow):
+    async def post_model_run(  # type: ignore[override]
+        self,
+        model: str,
+        arguments: Mapping[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        timeout: Any = None,
+    ) -> dict[str, Any]:
+        return self._attempt(arguments, idempotency_key)
+
+
 MODEL = "acme/flux/dev"
 ARGS = {"prompt": "a cat", "steps": 4}
 
@@ -51,62 +111,86 @@ ARGS = {"prompt": "a cat", "steps": 4}
 #: is only that the attempts happen at all.
 FAST = RetryPolicy(max_elapsed=5.0, initial_backoff=0.01, max_backoff=0.02)
 
+#: ``FAST`` for a deployment that replays a repeated key, which is the only
+#: kind against which retrying an unknown outcome is correct.
+FAST_OPTED_IN = RetryPolicy(
+    max_elapsed=5.0, initial_backoff=0.01, max_backoff=0.02, retry_possibly_in_flight=True
+)
+
+
+def _models(low: _FlakyLow, policy: RetryPolicy = FAST) -> Models:
+    return Models(cast(Any, low), policy)
+
+
+def _async_models(low: _AsyncFlakyLow, policy: RetryPolicy = FAST) -> AsyncModels:
+    return AsyncModels(cast(Any, low), policy)
+
 
 # --- the same key on every attempt of one call ---------------------------
 
 
-def test_every_attempt_of_one_call_sends_the_same_idempotency_key(server) -> None:
+def test_every_attempt_of_one_call_sends_the_same_idempotency_key() -> None:
     # The assertion that prevents the double charge: three attempts, one key.
     # A retry carrying a fresh key would read server-side as three separate
     # generations to run and bill.
-    server.state.model_run_fail_times = 2
-    with Comfy(retry=FAST) as client:
-        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
-    keys = server.state.model_run_idempotency_keys
-    assert server.state.model_run_count == 3
-    assert len(keys) == 3
-    assert all(k for k in keys)
-    assert len(set(keys)) == 1
+    low = _FlakyLow(fail_times=2)
+    assert _models(low).run(MODEL, ARGS) == low.result
+    assert len(low.keys) == 3
+    assert all(k for k in low.keys)
+    assert len(set(low.keys)) == 1
 
 
-async def test_every_attempt_of_one_async_call_sends_the_same_key(server) -> None:
-    server.state.model_run_fail_times = 2
-    async with AsyncComfy(retry=FAST) as client:
-        assert await client.models.run(MODEL, ARGS) == server.state.model_run_result
-    keys = server.state.model_run_idempotency_keys
-    assert len(keys) == 3
-    assert len(set(keys)) == 1
+async def test_every_attempt_of_one_async_call_sends_the_same_key() -> None:
+    low = _AsyncFlakyLow(fail_times=2)
+    assert await _async_models(low).run(MODEL, ARGS) == low.result
+    assert len(low.keys) == 3
+    assert len(set(low.keys)) == 1
 
 
-def test_a_second_call_is_a_new_key_even_though_both_retried(server) -> None:
+def test_a_second_call_is_a_new_key_even_though_both_retried() -> None:
     # The other half of the contract: a key is per logical call, not per
     # client and not per process. Two calls that each retried must not share
     # one — that would make the second call a replay of the first.
-    server.state.model_run_fail_times = 1
-    with Comfy(retry=FAST) as client:
-        client.models.run(MODEL, ARGS)
-        server.state.model_run_fail_times = 1
-        client.models.run(MODEL, ARGS)
-    keys = server.state.model_run_idempotency_keys
-    first_call, second_call = keys[:2], keys[2:]
+    low = _FlakyLow(fail_times=1)
+    models = _models(low)
+    models.run(MODEL, ARGS)
+    low.fail_times = 1
+    models.run(MODEL, ARGS)
+    first_call, second_call = low.keys[:2], low.keys[2:]
     assert len(set(first_call)) == 1
     assert len(set(second_call)) == 1
     assert set(first_call) != set(second_call)
 
 
 async def test_a_second_async_call_is_a_new_key(server) -> None:
-    async with AsyncComfy(retry=FAST) as client:
+    async with AsyncComfy() as client:
         await client.models.run(MODEL, ARGS)
         await client.models.run(MODEL, ARGS)
     first, second = server.state.model_run_idempotency_keys
     assert first != second
 
 
-def test_an_explicit_key_is_reused_across_retries_verbatim(server) -> None:
-    server.state.model_run_fail_times = 2
-    with Comfy(retry=FAST) as client:
-        client.models.run(MODEL, ARGS, idempotency_key="caller-chosen-07")
-    assert server.state.model_run_idempotency_keys == ["caller-chosen-07"] * 3
+def test_an_explicit_key_is_reused_across_retries_verbatim() -> None:
+    low = _FlakyLow(fail_times=2)
+    _models(low).run(MODEL, ARGS, idempotency_key="caller-chosen-07")
+    assert low.keys == ["caller-chosen-07"] * 3
+
+
+def test_the_body_is_frozen_before_the_first_attempt() -> None:
+    # A mutation between attempts would put a different body under the *same*
+    # key, which is the same-key-different-body case the contract rejects
+    # outright — so the payload is snapshotted where the key is minted.
+    arguments: dict[str, Any] = {"prompt": "a cat"}
+
+    class _MutatingLow(_FlakyLow):
+        def _attempt(self, args: Mapping[str, Any], key: str | None) -> dict[str, Any]:
+            result = super()._attempt(args, key)
+            arguments["prompt"] = "something else entirely"
+            return result
+
+    low = _MutatingLow(fail_times=2)
+    _models(low).run(MODEL, arguments)
+    assert [p["prompt"] for p in low.payloads] == ["a cat"] * 3
 
 
 # --- what gets retried ---------------------------------------------------
@@ -114,24 +198,31 @@ def test_an_explicit_key_is_reused_across_retries_verbatim(server) -> None:
 
 def test_retry_is_on_by_default(server) -> None:
     # No `retry=` argument anywhere: a transient failure is survived out of
-    # the box, which is the point of the default being on.
+    # the box, which is the point of the default being on. A 429 that names a
+    # pace is the wire-level failure the *default* policy retries — the
+    # contract releases the key for a reject that started no work.
     server.state.model_run_fail_times = 1
+    server.state.model_run_transient_error = (429, "concurrency_limit_exceeded")
+    server.state.model_run_retry_after = "0"
     with Comfy() as client:
         assert client.models.run(MODEL, ARGS) == server.state.model_run_result
     assert server.state.model_run_count == 2
+    assert len(set(server.state.model_run_idempotency_keys)) == 1
 
 
 def test_the_default_policy_retries_and_bounds_by_elapsed_time() -> None:
     assert DEFAULT_RETRY.enabled
     assert DEFAULT_RETRY.max_elapsed > 0
     assert DEFAULT_RETRY.jitter
-    # Off by default: retrying a request that may still be generating is only
-    # safe against a server that replays the key rather than re-running it.
+    # Off by default: retrying a request whose outcome is unknown is only
+    # correct against a server that replays the key rather than rejecting it.
     assert not DEFAULT_RETRY.retry_possibly_in_flight
 
 
 def test_retry_can_be_disabled(server) -> None:
     server.state.model_run_fail_times = 1
+    server.state.model_run_transient_error = (429, "concurrency_limit_exceeded")
+    server.state.model_run_retry_after = "0"
     with Comfy(retry=NO_RETRY) as client:
         with pytest.raises(ComfyError):
             client.models.run(MODEL, ARGS)
@@ -140,6 +231,8 @@ def test_retry_can_be_disabled(server) -> None:
 
 async def test_retry_can_be_disabled_on_the_async_client(server) -> None:
     server.state.model_run_fail_times = 1
+    server.state.model_run_transient_error = (429, "concurrency_limit_exceeded")
+    server.state.model_run_retry_after = "0"
     async with AsyncComfy(retry=NO_RETRY) as client:
         with pytest.raises(ComfyError):
             await client.models.run(MODEL, ARGS)
@@ -175,15 +268,39 @@ def test_a_deterministic_refusal_is_never_retried(server, status: int, code: str
     assert server.state.model_run_count == 1
 
 
-def test_a_429_is_not_retried_by_this_policy(server) -> None:
-    # Deliberate: a 429 names its own pace in `Retry-After`, and honouring that
-    # is a different mechanism from the blind backoff here. Blindly retrying it
-    # would ignore the pace the server asked for.
+def test_a_429_without_a_pace_is_not_retried(server) -> None:
+    # The spec's retry signal is "429 + Retry-After". One without a pace is
+    # not asking to be asked again, and guessing a delay for it is the
+    # thundering-herd case full jitter exists to avoid.
     server.state.model_run_error = (429, "queue_full")
     with Comfy(retry=FAST) as client:
         with pytest.raises(ComfyError):
             client.models.run(MODEL, ARGS)
     assert server.state.model_run_count == 1
+
+
+def test_a_429_that_names_a_pace_is_retried_at_that_pace(server) -> None:
+    # The transport already parses Retry-After onto the error; discarding it
+    # and backing off blind is what would re-flatten a server that just told
+    # us how fast to come back.
+    server.state.model_run_fail_times = 2
+    server.state.model_run_transient_error = (429, "queue_full")
+    server.state.model_run_retry_after = "0"
+    with Comfy(retry=FAST) as client:
+        assert client.models.run(MODEL, ARGS) == server.state.model_run_result
+    assert server.state.model_run_count == 3
+    assert len(set(server.state.model_run_idempotency_keys)) == 1
+
+
+def test_the_server_named_pace_is_used_instead_of_the_backoff_schedule() -> None:
+    clock = _FakeClock()
+    policy = RetryPolicy(max_elapsed=60.0, initial_backoff=1.0, max_backoff=2.0, jitter=False)
+    retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
+    paced = ComfyError("slow down", code="queue_full", http_status=429)
+    paced.retry_after = 7  # type: ignore[attr-defined]
+    # 7s is well above `max_backoff`: a pace the server named is honoured as
+    # given rather than capped by a ceiling meant for our own guesswork.
+    assert retrier.delay_before_retry(paced) == 7.0
 
 
 async def test_a_deterministic_refusal_is_never_retried_on_the_async_client(server) -> None:
@@ -195,17 +312,37 @@ async def test_a_deterministic_refusal_is_never_retried_on_the_async_client(serv
 
 
 @pytest.mark.parametrize("status", [500, 502, 503, 504])
-def test_a_5xx_is_retried(server, status: int) -> None:
+def test_a_5xx_is_not_retried_against_a_reject_on_duplicate_server(server, status: int) -> None:
+    # The heart of it. The contract keeps the key *claimed* when the outcome is
+    # unknown, so a same-key retry after a 5xx cannot succeed — it comes back
+    # 422 idempotency_key_reuse and replaces the real error with a confusing
+    # one. So the default policy does not make it, and the caller sees the 5xx.
+    server.state.model_run_error = (status, "internal_error")
+    with Comfy(retry=FAST) as client:
+        with pytest.raises(ComfyError) as excinfo:
+            client.models.run(MODEL, ARGS)
+    assert server.state.model_run_count == 1
+    assert excinfo.value.http_status == status
+    assert not isinstance(excinfo.value, IdempotencyKeyReuse)
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_a_5xx_is_retried_under_the_replay_opt_in(server, status: int) -> None:
+    server.state.model_run_replays_idempotency_key = True
     server.state.model_run_transient_error = (status, "internal_error")
     server.state.model_run_fail_times = 1
-    with Comfy(retry=FAST) as client:
+    with Comfy(retry=FAST_OPTED_IN) as client:
         assert client.models.run(MODEL, ARGS) == server.state.model_run_result
     assert server.state.model_run_count == 2
+    assert len(set(server.state.model_run_idempotency_keys)) == 1
 
 
 def test_a_permanent_5xx_eventually_surfaces_as_the_sdk_error(server) -> None:
+    server.state.model_run_replays_idempotency_key = True
     server.state.model_run_error = (500, "internal_error")
-    policy = RetryPolicy(max_elapsed=0.2, initial_backoff=0.01, max_backoff=0.02)
+    policy = RetryPolicy(
+        max_elapsed=0.2, initial_backoff=0.01, max_backoff=0.02, retry_possibly_in_flight=True
+    )
     with Comfy(retry=policy) as client:
         with pytest.raises(ComfyError) as excinfo:
             client.models.run(MODEL, ARGS)
@@ -240,6 +377,7 @@ async def test_an_async_client_timeout_is_not_retried_by_default(server) -> None
 def test_opting_in_retries_a_client_timeout_under_the_one_key(server) -> None:
     # The opt-in for a server that replays a repeated key. Even here the key is
     # unchanged, so the second attempt is the same request, not a second order.
+    server.state.model_run_replays_idempotency_key = True
     server.state.model_run_delay = 1.5
     policy = RetryPolicy(
         max_elapsed=1.0,
@@ -273,8 +411,11 @@ def test_retries_stop_at_the_elapsed_budget_not_at_an_attempt_count(server) -> N
     # A per-attempt budget multiplies: N attempts each granted their own wait
     # stack into a total nobody chose. This bound is wall-clock across the
     # whole call, so however cheap an attempt is, the call still ends.
+    server.state.model_run_replays_idempotency_key = True
     server.state.model_run_error = (503, "internal_error")
-    policy = RetryPolicy(max_elapsed=0.3, initial_backoff=0.01, max_backoff=0.02)
+    policy = RetryPolicy(
+        max_elapsed=0.3, initial_backoff=0.01, max_backoff=0.02, retry_possibly_in_flight=True
+    )
     started = time.monotonic()
     with Comfy(retry=policy) as client:
         with pytest.raises(ComfyError):
@@ -288,28 +429,61 @@ def test_retries_stop_at_the_elapsed_budget_not_at_an_attempt_count(server) -> N
 
 def test_the_deadline_is_measured_from_the_first_attempt() -> None:
     clock = _FakeClock()
-    policy = RetryPolicy(max_elapsed=10.0, initial_backoff=1.0, max_backoff=1.0, jitter=False)
+    policy = RetryPolicy(
+        max_elapsed=10.0,
+        initial_backoff=1.0,
+        max_backoff=1.0,
+        jitter=False,
+        retry_possibly_in_flight=True,
+    )
     retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
     failure = InternalError("boom", http_status=500)
 
-    # Nine one-second waits fit inside the ten-second budget...
-    for _ in range(9):
+    # Ten one-second waits fit inside the ten-second budget...
+    for _ in range(10):
         delay = retrier.delay_before_retry(failure)
         assert delay == 1.0
         clock.advance(delay)
-    # ...and the tenth would start an attempt at the deadline, so it does not.
+    # ...and by then the budget is spent, so no further attempt starts.
     assert retrier.delay_before_retry(failure) is None
-    assert retrier.attempts == 10
+    assert retrier.attempts == 11
 
 
-def test_a_slow_attempt_spends_the_budget_it_actually_used() -> None:
-    # The bound is elapsed time, so one attempt that takes most of the budget
-    # leaves no room for another — however few attempts have been made.
+def test_a_delay_that_would_overshoot_is_clamped_to_what_is_left() -> None:
+    # Clamped rather than abandoned: with full jitter drawn over [0, ceiling],
+    # one unlucky draw would otherwise end a call that still had seconds of
+    # budget, making identical calls take a randomly varying number of
+    # attempts. `client.py::_retry_delay` bounds its 429 wait the same way.
     clock = _FakeClock()
-    policy = RetryPolicy(max_elapsed=10.0, initial_backoff=1.0, max_backoff=1.0, jitter=False)
+    policy = RetryPolicy(
+        max_elapsed=10.0,
+        initial_backoff=1.0,
+        max_backoff=1.0,
+        jitter=False,
+        retry_possibly_in_flight=True,
+    )
     retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
     clock.advance(9.5)
+    assert retrier.delay_before_retry(InternalError("boom", http_status=500)) == 0.5
+
+
+def test_a_spent_budget_yields_no_delay_at_all() -> None:
+    clock = _FakeClock()
+    policy = RetryPolicy(max_elapsed=10.0, retry_possibly_in_flight=True)
+    retrier = Retrier(policy, now=clock, rng=lambda: 1.0)
+    clock.advance(10.0)
     assert retrier.delay_before_retry(InternalError("boom", http_status=500)) is None
+
+
+def test_a_short_budget_still_retries_rather_than_reporting_a_lie() -> None:
+    # `enabled` is True here, and now it means something: the first delay is
+    # clamped into the budget instead of the policy silently never retrying.
+    policy = RetryPolicy(max_elapsed=0.3, retry_possibly_in_flight=True)
+    assert policy.enabled
+    retrier = Retrier(policy, now=_FakeClock(), rng=lambda: 1.0)
+    delay = retrier.delay_before_retry(InternalError("boom", http_status=500))
+    assert delay is not None
+    assert 0 < delay <= 0.3
 
 
 def test_a_disabled_policy_never_yields_a_delay() -> None:
@@ -329,6 +503,23 @@ def test_backoff_grows_and_holds_at_the_ceiling() -> None:
 def test_backoff_cannot_overflow_on_a_pathological_attempt_count() -> None:
     policy = RetryPolicy(initial_backoff=1.0, backoff_factor=2.0, max_backoff=8.0, jitter=False)
     assert policy.backoff(100_000) == 8.0
+
+
+def test_backoff_cannot_overflow_on_a_pathological_factor() -> None:
+    # `initial_backoff * backoff_factor**exponent` is fully evaluated before
+    # any `min()` could cap it, and CPython's float `**` raises OverflowError
+    # rather than saturating — which would escape the retry loop and replace
+    # the genuine API error with an arithmetic one.
+    policy = RetryPolicy(initial_backoff=1.0, backoff_factor=1e200, max_backoff=8.0, jitter=False)
+    assert [policy.backoff(n) for n in range(1, 6)] == [1.0, 8.0, 8.0, 8.0, 8.0]
+
+
+def test_a_gentle_factor_keeps_growing_past_a_large_attempt_count() -> None:
+    # Clamping the exponent instead would freeze growth long before the
+    # ceiling for any factor that climbs slowly.
+    policy = RetryPolicy(initial_backoff=0.5, backoff_factor=1.01, max_backoff=15.0, jitter=False)
+    assert policy.backoff(66) > policy.backoff(65) > policy.backoff(64)
+    assert policy.backoff(1000) == 15.0
 
 
 def test_jitter_spreads_each_delay_below_its_ceiling() -> None:
@@ -363,6 +554,29 @@ def test_an_incoherent_policy_is_rejected_at_construction(kwargs: dict) -> None:
         RetryPolicy(**kwargs)
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # Infinity passes every ordered check and never reaches its deadline,
+        # so `run` would retry a permanently failing server forever.
+        {"max_elapsed": float("inf")},
+        # NaN fails every ordered check, so it constructs and then misbehaves:
+        # a NaN budget reads as "retrying disabled", a NaN backoff makes the
+        # caller's `sleep` raise in place of the real error.
+        {"max_elapsed": float("nan")},
+        {"initial_backoff": float("nan")},
+        {"backoff_factor": float("nan")},
+        {"max_backoff": float("nan")},
+        {"max_backoff": float("inf")},
+        {"backoff_factor": float("inf")},
+    ],
+    ids=lambda v: str(v),
+)
+def test_a_non_finite_policy_is_rejected_at_construction(kwargs: dict) -> None:
+    with pytest.raises(ValueError):
+        RetryPolicy(**kwargs)
+
+
 def test_a_policy_is_immutable() -> None:
     # Shared by every call on a client, so one call cannot rewrite another's.
     with pytest.raises(AttributeError):
@@ -373,13 +587,28 @@ def test_a_policy_is_immutable() -> None:
 
 
 @pytest.mark.parametrize("status", [500, 501, 502, 503, 504, 599])
-def test_5xx_is_retryable(status: int) -> None:
-    assert is_retryable_status(status)
+def test_5xx_leaves_the_outcome_unknown(status: int) -> None:
+    assert is_unknown_outcome_status(status)
+    # ...and so is not retried unless the deployment replays repeated keys.
+    assert not DEFAULT_RETRY.should_retry(InternalError("boom", http_status=status))
+    opted_in = RetryPolicy(retry_possibly_in_flight=True)
+    assert opted_in.should_retry(InternalError("boom", http_status=status))
 
 
 @pytest.mark.parametrize("status", [200, 400, 401, 402, 403, 404, 409, 422, 429, 499])
-def test_everything_below_500_is_not(status: int) -> None:
-    assert not is_retryable_status(status)
+def test_everything_below_500_has_a_known_outcome(status: int) -> None:
+    assert not is_unknown_outcome_status(status)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [(0, 0.0), (5, 5.0), (2.5, 2.5), (None, None), (-1, None), (float("nan"), None), ("3", None)],
+    ids=lambda v: str(v),
+)
+def test_a_named_pace_is_read_off_the_error_or_treated_as_absent(raw, expected) -> None:
+    exc = ComfyError("throttled", code="queue_full", http_status=429)
+    exc.retry_after = raw  # type: ignore[attr-defined]
+    assert retry_after_of(exc) == expected
 
 
 def test_a_typed_router_refusal_is_classified_by_its_status() -> None:
@@ -387,7 +616,30 @@ def test_a_typed_router_refusal_is_classified_by_its_status() -> None:
     # a typed router error is judged the same way as the protocol error the
     # model surface raises today.
     assert not DEFAULT_RETRY.should_retry(ContentPolicyViolation("refused", http_status=400))
-    assert DEFAULT_RETRY.should_retry(InternalError("boom", http_status=500))
+    opted_in = RetryPolicy(retry_possibly_in_flight=True)
+    assert opted_in.should_retry(InternalError("boom", http_status=500))
+
+
+def test_a_router_error_reaches_the_retry_loop_at_all() -> None:
+    # Router errors derive from ComfyError, not ApiError, so a `run` that only
+    # caught ApiError would never hand one to the policy — making the branch
+    # above unreachable and retry a silent no-op the day this route raises
+    # them.
+    class _RouterFailingLow(_FlakyLow):
+        def _attempt(self, args: Mapping[str, Any], key: str | None) -> dict[str, Any]:
+            self.keys.append(key)
+            if self.fail_times > 0:
+                self.fail_times -= 1
+                raise InternalError("upstream blew up", http_status=500)
+            return self.result
+
+    low = _RouterFailingLow(fail_times=1)
+    policy = RetryPolicy(
+        max_elapsed=5.0, initial_backoff=0.01, max_backoff=0.02, retry_possibly_in_flight=True
+    )
+    assert _models(low, policy).run(MODEL, ARGS) == low.result
+    assert len(low.keys) == 2
+    assert len(set(low.keys)) == 1
 
 
 @pytest.mark.parametrize(
@@ -401,7 +653,7 @@ def test_a_typed_router_refusal_is_classified_by_its_status() -> None:
 )
 def test_a_connect_phase_failure_is_retryable(exc: Exception) -> None:
     # The request was never delivered, so there is nothing running server-side
-    # for a retry to duplicate.
+    # for a retry to duplicate and the key was never claimed.
     assert DEFAULT_RETRY.should_retry(exc)
 
 


### PR DESCRIPTION
## ELI-5

Running a model is a request that can take minutes, because the server holds the connection open until the picture is finished. If the connection breaks and the client just asks again, the server starts a *second* generation — and you get charged twice for one request. This adds automatic retry to `client.models.run`, and the thing that makes it safe is that **every attempt of one call sends the same `Idempotency-Key`**. A new call gets a new key. That is what lets the server tell "same request, asked again" apart from "a second order".

The same key is also what decides *which* failures are worth retrying — see the judgment call below, which review substantially reshaped.

## What changed

- New `comfy_sdk.retry` module: `RetryPolicy` (frozen dataclass), `DEFAULT_RETRY`, `NO_RETRY`, `Retrier`, `is_unknown_outcome_status`, `retry_after_of`. All sans-IO — it decides *whether* and *how long* to wait; the sync and async layers do the waiting.
- `Models.run` / `AsyncModels.run` mint the `Idempotency-Key` **once, outside the retry loop**, reuse it verbatim on every attempt, and snapshot the request body in the same place so a mutation between attempts cannot put a different body under the one key.
- `Comfy(retry=...)` / `AsyncComfy(retry=...)` set the policy; `client.models.retry` reads it back.
- README section documenting the default policy, plus a CHANGELOG entry.
- Test stub gained `model_run_fail_times` / `model_run_transient_error` / `model_run_retry_after`, and now enforces the same reject-on-duplicate `Idempotency-Key` rule that `_post_jobs` already enforced — with `model_run_replays_idempotency_key` to model the replaying deployment the opt-in exists for.

The default policy retries exactly the failures that leave the one key still spendable:

| Class | Default |
|---|---|
| Never delivered — `ConnectError`, `ConnectTimeout`, `PoolTimeout`, `ProxyError`. The request never reached submission, so the key was never claimed | retried |
| Rejected without starting work — a `429` carrying `Retry-After`. The contract releases the key for exactly this, and instructs clients to treat "429 + `Retry-After`" as back-off-and-retry | retried, at the pace the server named |
| Outcome unknown — **any 5xx**, plus read/write timeouts and `RemoteProtocolError`. The key stays claimed across these | only with `retry_possibly_in_flight=True` |
| Every other 4xx, and a `429` with no pace | never |

Budget is 60s of total elapsed time from the first attempt. Backoff 0.5s doubling to a 15s ceiling, full jitter, clamped to whatever is left of the budget.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Same key on every attempt; new key per call | `Models.run` hoists `key` above the loop — `test_every_attempt_of_one_call_sends_the_same_idempotency_key`, `test_a_second_call_is_a_new_key_even_though_both_retried`, and the async pair |
| A test asserts identical-across-retries / different-across-calls | the two above; three failed attempts, one key |
| Bounded by total elapsed time, not attempt count | `RetryPolicy.max_elapsed`, deadline fixed at `Retrier.__init__`. `test_the_deadline_is_measured_from_the_first_attempt` and `test_a_delay_that_would_overshoot_is_clamped_to_what_is_left` assert the arithmetic against a fake clock, so it is exact rather than timing-dependent |
| Only retryable conditions retried; 422 / 409 / 404 / content-policy not | `test_a_deterministic_refusal_is_never_retried` (parametrised over 400 content_policy_violation, 404, 409, 422, 401, 402), `test_a_typed_router_refusal_is_classified_by_its_status` |
| Backoff with jitter | `RetryPolicy.backoff`, full jitter — `test_jitter_spreads_each_delay_below_its_ceiling`, `test_backoff_grows_and_holds_at_the_ceiling` |
| On by default, can be disabled, default documented | `test_retry_is_on_by_default`, `test_retry_can_be_disabled` (+ async), README table, CHANGELOG |
| Interaction with the long client timeout is explicit; a retry must not begin while the original may still be in flight | see the judgment call below — `test_a_client_timeout_is_not_retried_by_default`, `test_opting_in_retries_a_client_timeout_under_the_one_key`, `test_the_retry_deadline_never_interrupts_an_attempt` |

All seven are met. None skipped.

## Judgment calls

**Nothing whose outcome is unknown is retried by default — and that now includes 5xx.** This is the one call with two defensible readings, and review was right that the first revision took the wrong one. "Transport failures and 5xx are retryable" says retry them; "a retry must not begin while the original request may still be in flight server-side" says do not. What settles it is the key's own contract rather than a guess about the network.

Every documented statement this repo makes about `Idempotency-Key` says it is single-use, reject-on-duplicate, with **no response replay**: `spec/openapi.yaml`'s shared `IdempotencyKey` parameter, `comfy_sdk.exceptions.IdempotencyKeyReuse`, and README:405. The spec is equally explicit about which failures *release* a key versus *claim* it — a request that "definitively fails without creating a job (a validation error, or an upstream reject such as out-of-credits or queue-full)" frees it, while one whose outcome the server cannot characterise ("an upstream timeout or 5xx where the job may or may not have been created") keeps it claimed. `POST /models/run` is not itself in the spec, so its key semantics are undocumented — and undocumented cannot be read as "replays".

So retrying a completed 5xx under the unchanged key could not do what the first revision claimed: against a reject-on-duplicate server it returns `422 idempotency_key_reuse` and *replaces* the genuine 5xx with a confusing one, and a fresh-key retry is the second billed generation this change exists to prevent. 5xx therefore joins the client-side timeout behind `retry_possibly_in_flight`, which already meant "my deployment replays a repeated key" and so needed no new concept.

This is not a dead end, and nothing is removed: 5xx retry is still reachable and tested in both directions — `test_a_5xx_is_not_retried_against_a_reject_on_duplicate_server` proves the default (and that the caller sees the real 5xx, not an `IdempotencyKeyReuse` standing in for it), `test_a_5xx_is_retried_under_the_replay_opt_in` proves the opt-in retries, still under the one key.

**`429` with a `Retry-After` *is* now retried, at the server's pace.** The reverse of the first revision, and for the same contract reason: a 429 is precisely the reject that starts no work, so the key is released and remains spendable, and the spec tells clients to treat "429 + `Retry-After`" as back-off-and-retry. The transport already parses `Retry-After` onto the error; the policy now honours it instead of backing off blind. A 429 with no pace stays non-retryable — without one it is not asking to be asked again. This also makes the default policy useful on a surface where the workflow-submit 429 handling in `client.py` does not reach.

**Structural guarantees, unchanged.** A client can never *prove* the server stopped, so "must not begin while the original may still be in flight" is also enforced structurally: attempts are strictly sequential (one connection closed and the backoff elapsed before the next opens, never two at once), and the retry deadline never interrupts an attempt — it is checked only *between* attempts, so a slow generation is never abandoned half-way. Consequence, stated plainly: the deadline bounds when the **last attempt may start**, so worst-case wall clock is the budget plus one per-attempt `timeout`.

**An overshooting delay is clamped, not treated as a refusal.** `delay_before_retry` returns `min(delay, remaining)`, matching `client.py::_retry_delay`. With full jitter, giving up on an unlucky draw made identical calls take a randomly varying number of attempts and let `RetryPolicy(max_elapsed=0.3)` report `enabled is True` while never retrying. `max_elapsed` is now the inclusive bound on when the last attempt may start.

**One existing test changed.** `test_an_unmapped_failure_still_lands_as_a_comfy_error` drives a permanently-failing 503. It passes `retry=NO_RETRY`, with a comment saying the mapping is what is under test. Its assertions are unchanged.

## The half not fixed, measured

Swept every site in `src/comfy_sdk` that mints an `Idempotency-Key` (3) and every request-retry loop (2, excluding job-poll loops which are a different concern and out of scope here):

- `client.models.run` — the one this PR fixes: had no retry at all, and minted its key inline at the call.
- `Comfy.submit` / `AsyncComfy.submit` — **already correct, left alone**: the key is already hoisted above their 429 loop, and that loop is already bounded by a 60s elapsed budget.
- `Asset.commit` / `AsyncAsset.commit` — **no retry loop at all**, and the key is per handle, so it is already stable if a caller retries by hand. Not given a policy: out of scope, and an upload is not the billed-generation shape this ticket is about.

So of the 3 key-bearing surfaces, 1 needed the fix and 2 already satisfied the same-key-across-attempts property. No surface was found re-minting a key inside a retry loop other than the one fixed.

## Not addressed here

- Server-side idempotency storage and replay semantics — separately tracked; this is the client half, and the two are complementary. Confirming (and documenting) whether `POST /models/run` replays a repeated key is what would let 5xx move back to the default.
- Warning when `max_elapsed` is below the per-attempt run timeout, which makes `retry_possibly_in_flight` inert on its own — raised in review, deferred to a follow-up because siting it in `run` and choosing warn-vs-log-vs-document is a deliberate ergonomics call rather than a contract fix.
- Retrying inside the server's own poll loop, and circuit breaking / adaptive rate limiting — explicitly out of scope for v1.
- No per-call `retry=` override on `run()`. Deliberate: `run(timeout=None)` already means "wait forever", so a `retry=None` sitting next to it would read as "no retry" while meaning "inherit". Adding the keyword later is backward compatible.

## Unexercised artifacts

The source ticket links four provenance items (an internal decision record, a Slack thread, a planning doc, and a companion server-side ticket). None are readable from this environment, so none were opened — the acceptance criteria in the ticket body are what this was built and verified against. Nothing in this PR was verified against a live deployment: the integration suite (`tests/integration/`) skips without a real base URL and key, so all evidence below is the stubbed server in `tests/conftest.py`. In particular, the reject-on-duplicate behaviour of `POST /models/run` is taken from the vendored spec's header contract, not observed on a real server — which is exactly why the unknown-outcome class is gated rather than guessed at.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `ruff check .` clean; `ruff format --check .` 50 files already formatted; `mypy src` no issues in 19 source files; `pytest -q` 438 passed, 4 skipped; `scripts/check_public_repo_hygiene.py` OK; `scripts/check_drift.py` models in sync; `uv build` + `twine check dist/*` both PASSED
- **Deviations:** all seven acceptance criteria met. The interpretive call on what is retried by default was *reversed* during review and is argued above: 5xx moved from retried-by-default to behind `retry_possibly_in_flight`, and `429`-with-`Retry-After` moved from never-retried to retried-by-default, both because the `Idempotency-Key` contract — not the transport — determines which retries a single key can survive. One review finding (a warning when the retry budget is below the per-attempt run timeout) is deferred to a follow-up rather than fixed here.
