### PR TITLE
Revert "feat: add expires_in parameter to asset upload endpoints"

### DIFF
--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -558,7 +558,6 @@ class ComfyLow:
         tags: list[str] | None = None,
         idempotency_key: str | None = None,
         file_size: int | None = None,
-        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         """POST /api/v2/assets — streaming multipart upload."""
@@ -574,8 +573,6 @@ class ComfyLow:
             # One part per tag — repeating the field name is the multipart/form
             # convention for a list, and a dict would silently drop all but one.
             fields.extend(("tags", t) for t in tags)
-        if expires_in is not None:
-            fields.append(("expires_in", str(expires_in)))
         boundary = _new_boundary()
         body, length = _multipart.build_multipart(
             boundary,
@@ -600,7 +597,6 @@ class ComfyLow:
         *,
         file_path: str | None = None,
         tags: list[str] | None = None,
-        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         """POST /api/v2/assets/from-hash — dedup mint over existing bytes."""
@@ -609,8 +605,6 @@ class ComfyLow:
             payload["file_path"] = file_path
         if tags is not None:
             payload["tags"] = tags
-        if expires_in is not None:
-            payload["expires_in"] = expires_in
         resp = self.raw_request("POST", "/assets/from-hash", json=payload, timeout=timeout)
         data = self._p.parse_or_raise(resp, (200, 201))
         return Asset.model_validate(data)
@@ -923,7 +917,6 @@ class AsyncComfyLow:
         tags: list[str] | None = None,
         idempotency_key: str | None = None,
         file_size: int | None = None,
-        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         if file_size is None:
@@ -937,8 +930,6 @@ class AsyncComfyLow:
         if tags:
             # One part per tag — see the sync ``post_assets`` for why a dict is wrong.
             fields.extend(("tags", t) for t in tags)
-        if expires_in is not None:
-            fields.append(("expires_in", str(expires_in)))
         boundary = _new_boundary()
         body, length = _multipart.build_multipart(
             boundary,
@@ -973,7 +964,6 @@ class AsyncComfyLow:
         *,
         file_path: str | None = None,
         tags: list[str] | None = None,
-        expires_in: int | None = None,
         timeout: Any = _UNSET,
     ) -> Asset:
         payload: dict[str, Any] = {"hash": hash}
@@ -981,8 +971,6 @@ class AsyncComfyLow:
             payload["file_path"] = file_path
         if tags is not None:
             payload["tags"] = tags
-        if expires_in is not None:
-            payload["expires_in"] = expires_in
         resp = await self.raw_request("POST", "/assets/from-hash", json=payload, timeout=timeout)
         data = self._p.parse_or_raise(resp, (200, 201))
         return Asset.model_validate(data)

--- a/src/comfy_sdk/assets.py
+++ b/src/comfy_sdk/assets.py
@@ -42,7 +42,6 @@ class _Source:
     file_path: str
     hasher: Hasher
     opener: Opener
-    expires_in: int | None = None
 
 
 def _guess_content_type(name: str | None) -> str:
@@ -61,7 +60,6 @@ class _AssetBase:
         self._file_path = source.file_path
         self._hasher = source.hasher
         self._opener = source.opener
-        self._expires_in = source.expires_in
         self._hash: str | None = None
         self._id: str | None = None
         self._created_new: bool | None = None
@@ -129,9 +127,7 @@ class Asset(_AssetBase):
         digest = self.hash
         with translating():
             if self._low.head_asset_by_hash(digest):
-                asset = self._low.asset_from_hash(
-                    digest, file_path=self._file_path, expires_in=self._expires_in
-                )
+                asset = self._low.asset_from_hash(digest, file_path=self._file_path)
             else:
                 fh, size = self._opener()
                 try:
@@ -142,7 +138,6 @@ class Asset(_AssetBase):
                         expected_hash=digest,
                         idempotency_key=self._idempotency_key,
                         file_size=size,
-                        expires_in=self._expires_in,
                     )
                 finally:
                     fh.close()
@@ -178,9 +173,7 @@ class AsyncAsset(_AssetBase):
         digest = self.hash
         with translating():
             if await self._low.head_asset_by_hash(digest):
-                asset = await self._low.asset_from_hash(
-                    digest, file_path=self._file_path, expires_in=self._expires_in
-                )
+                asset = await self._low.asset_from_hash(digest, file_path=self._file_path)
             else:
                 fh, size = self._opener()
                 try:
@@ -191,7 +184,6 @@ class AsyncAsset(_AssetBase):
                         expected_hash=digest,
                         idempotency_key=self._idempotency_key,
                         file_size=size,
-                        expires_in=self._expires_in,
                     )
                 finally:
                     fh.close()
@@ -216,7 +208,7 @@ class AsyncAsset(_AssetBase):
 # ---- source builders (shared, sans-IO except explicit reads) ------------
 
 
-def _file_source(path: str | PathLike[str], *, expires_in: int | None = None) -> _Source:
+def _file_source(path: str | PathLike[str]) -> _Source:
     p = str(path)
     name = basename(p)
     return _Source(
@@ -224,7 +216,6 @@ def _file_source(path: str | PathLike[str], *, expires_in: int | None = None) ->
         file_path=name,
         hasher=lambda: _hashing.hash_file(p),
         opener=lambda: (open(p, "rb"), getsize(p)),
-        expires_in=expires_in,
     )
 
 
@@ -244,8 +235,8 @@ class AssetFactory:
     def __init__(self, low: ComfyLow) -> None:
         self._low = low
 
-    def from_file(self, path: str | PathLike[str], *, expires_in: int | None = None) -> Asset:
-        return Asset(self._low, _file_source(path, expires_in=expires_in))
+    def from_file(self, path: str | PathLike[str]) -> Asset:
+        return Asset(self._low, _file_source(path))
 
     def from_bytes(
         self,
@@ -297,8 +288,8 @@ class AsyncAssetFactory:
     def __init__(self, low: AsyncComfyLow) -> None:
         self._low = low
 
-    def from_file(self, path: str | PathLike[str], *, expires_in: int | None = None) -> AsyncAsset:
-        return AsyncAsset(self._low, _file_source(path, expires_in=expires_in))
+    def from_file(self, path: str | PathLike[str]) -> AsyncAsset:
+        return AsyncAsset(self._low, _file_source(path))
 
     def from_bytes(
         self,


### PR DESCRIPTION
Reverts Comfy-Org/comfy-python-sdk#76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `expires_in` option from asset upload and retrieval operations.
  * Removed the `expires_in` option from synchronous and asynchronous file-based asset creation.
  * Existing integrations passing `expires_in` must remove this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->