### PR TITLE
fix(errors): a Router bucket outranks the status table on every status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ notes for each version.
 
 ### Fixed
 
+- A Router error now keeps its own bucket on **every** status, and
+  `client.models.run()` raises the matching typed `RouterError` subclass for
+  it. Previously the status table won for any status it named, so a `403`
+  `not_enabled` surfaced as `Forbidden` — `except NotEnabled`, the handler
+  every pre-launch caller writes, never fired — a `422` `invalid_input` as
+  `InvalidWorkflow`, and a `404` `model_not_found` as plain `NotFound`. The
+  retype only touches responses that carry a bucket (the `X-Comfy-Error-Type`
+  header or Router's top-level body `error_type`), which only Router sends:
+  the v2 envelope's `error.code` still always wins, a bucket-less response
+  still decodes off the status table (a bare `429` is still `QueueFull`), and
+  the three buckets both surfaces spell identically (`unauthorized`,
+  `forbidden`, `insufficient_credits`) keep their existing classes, which
+  catch on both surfaces. `Retry-After` pacing is keyed on the status and
+  survives unchanged.
 - A Router `409` now keeps the bucket the contract names instead of decoding
   to `HashMismatch` off the status table. The synced contract declares two
   `409`s on the run route — `invalid_input` for a key that cannot serve this

--- a/src/comfy_low/errors.py
+++ b/src/comfy_low/errors.py
@@ -175,7 +175,7 @@ def error_from_envelope(
     proxy-shaped responses it was built for.
 
     The bucket outranking the status table is the load-bearing choice, learned
-    three times on live traffic: the table turned Router's ``409``\ s into
+    three times on live traffic: the table turned Router's ``409`` errors into
     ``hash_mismatch`` (killing the contract's collect rule), its ``422``
     ``invalid_input`` into ``invalid_workflow`` (failing every reachability
     probe), and its ``403`` ``not_enabled`` into ``forbidden`` (so ``except

--- a/src/comfy_low/errors.py
+++ b/src/comfy_low/errors.py
@@ -168,26 +168,23 @@ def error_from_envelope(
     against every real Router ``504``. ``error_type`` (the header, passed by the
     caller) and the body's own top-level ``error_type`` are read to prevent that.
 
-    They are consulted in one narrow place, though: *after* the envelope's
-    ``code``, which always wins, and *after* :data:`_CODE_BY_STATUS`, which
-    already determines a code for every status where this API has a documented
-    one. So a Router ``429`` still maps to ``queue_full`` and a Router ``401``
-    still to ``unauthorized`` — reordering those would silently retype
-    exceptions that integrators already catch. What is left is exactly the 5xx
-    range, where the status determines nothing and the bucket is the only name
-    the response has.
+    The precedence is: the envelope's ``code`` always wins; then, when the
+    response identifies itself as Router's — the ``X-Comfy-Error-Type`` header
+    or a top-level body ``error_type`` is present — that bucket wins for EVERY
+    status; only then does :data:`_CODE_BY_STATUS` fill in, for the bare and
+    proxy-shaped responses it was built for.
 
-    ``409`` is the one carve-out from "the status table wins". The table's
-    ``hash_mismatch`` belongs to the v2 jobs/assets surface, but the router
-    contract now declares its own ``409`` responses (``invalid_input`` for a key that
-    cannot serve this request, ``concurrency_limit_exceeded`` for a key whose
-    call is still in flight — ``spec/router-openapi.yaml``), and those arrive
-    with no ``error.code`` at all. Left to the table, both would surface as
-    :class:`HashMismatch` — an asset-upload error — with the real bucket
-    destroyed before ``comfy_sdk.retry.error_bucket_of`` can read it, so the
-    contract's collect rule could never fire. A ``409`` that names a Router
-    bucket therefore keeps it; a bucket-less ``409`` still degrades to the
-    table exactly as before.
+    The bucket outranking the status table is the load-bearing choice, learned
+    three times on live traffic: the table turned Router's ``409``\ s into
+    ``hash_mismatch`` (killing the contract's collect rule), its ``422``
+    ``invalid_input`` into ``invalid_workflow`` (failing every reachability
+    probe), and its ``403`` ``not_enabled`` into ``forbidden`` (so ``except
+    NotEnabled`` — the one handler every pre-launch caller writes — never
+    fired). Retyping only happens on responses that carry a bucket, which only
+    Router sends, and there the bucket IS the truth; a v2 envelope carries
+    ``error.code`` and no top-level ``error_type``, and an intermediary's
+    reject carries neither, so both keep exactly the classes integrators
+    already catch.
     """
     err = (body or {}).get("error") if isinstance(body, dict) else None
     code = (err or {}).get("code") if isinstance(err, dict) else None
@@ -195,17 +192,11 @@ def error_from_envelope(
     details = (err or {}).get("details") if isinstance(err, dict) else None
 
     if code is None:
-        code = _CODE_BY_STATUS.get(http_status)
-        if http_status == 409:
-            router_bucket = _clean(error_type) or _clean(
-                (body or {}).get("error_type") if isinstance(body, dict) else None
-            )
-            if router_bucket is not None:
-                code = router_bucket
-    if code is None:
         code = _clean(error_type) or _clean(
             (body or {}).get("error_type") if isinstance(body, dict) else None
         )
+    if code is None:
+        code = _CODE_BY_STATUS.get(http_status)
     if code is None:
         code = "error"
     if not message:

--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -166,6 +166,29 @@ _BY_CODE: dict[str, type[ComfyError]] = {
 }
 
 
+def _router_only_class(code: str) -> type[Any] | None:
+    """The typed RouterError subclass for a code only Router produces, or None.
+
+    The low layer now preserves Router's wire bucket as the ``code`` for every
+    status, so this is what turns a preserved ``not_enabled`` into the
+    :class:`~comfy_sdk.router_exceptions.NotEnabled` a pre-launch caller
+    catches, instead of a bare ``ComfyError``.
+
+    Deliberately scoped to buckets the v2 envelope does NOT also use:
+    ``unauthorized``, ``forbidden`` and ``insufficient_credits`` are spelled
+    identically by both surfaces, and the code string alone cannot say which
+    answered — retyping those would break every jobs-surface ``except
+    Forbidden`` handler to fix none, since their v2 classes fire on the router
+    surface too. Imported lazily because :mod:`comfy_sdk.router_exceptions`
+    subclasses :class:`ComfyError` from this module.
+    """
+    from comfy_sdk.router_exceptions import _BY_ERROR_TYPE as _ROUTER_BY_TYPE
+
+    if code in _BY_CODE or code == "queue_full":
+        return None
+    return _ROUTER_BY_TYPE.get(code)
+
+
 def to_sdk_error(exc: ApiError) -> ComfyError:
     """Translate a protocol ``ApiError`` into the idiomatic SDK exception."""
     if exc.code == "queue_full":
@@ -176,6 +199,15 @@ def to_sdk_error(exc: ApiError) -> ComfyError:
             http_status=exc.http_status,
             details=exc.details,
             request_id=exc.request_id,
+        )
+    router_cls = _router_only_class(exc.code)
+    if router_cls is not None:
+        return router_cls(
+            exc.message,
+            error_type=exc.code,
+            http_status=exc.http_status,
+            request_id=exc.request_id,
+            retry_after=exc.retry_after,
         )
     cls = _BY_CODE.get(exc.code, ComfyError)
     return cls(

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -58,18 +58,41 @@ def test_routers_error_type_header_is_read_when_the_body_carries_none() -> None:
     assert err.message == "HTTP 504"
 
 
-def test_a_documented_status_code_is_not_retyped_by_the_bucket() -> None:
-    # The guard on the fallback's placement. Router's 429 bucket is
-    # `rate_limited` / `concurrency_limit_exceeded`, but this API's 429 has
-    # meant `queue_full` -- and `QueueFull` -- since before Router fronted
-    # anything. Letting the bucket win here would silently retype an exception
-    # integrators already catch, so the status-derived code is consulted first
-    # and only the 5xx range, where the status determines nothing, is left to
-    # the bucket.
-    err = error_from_envelope(429, None, error_type="concurrency_limit_exceeded", retry_after=3)
+@pytest.mark.parametrize(
+    ("status", "bucket"),
+    [
+        (403, "not_enabled"),
+        (404, "model_not_found"),
+        (409, "invalid_input"),
+        (422, "invalid_input"),
+        (429, "rate_limited"),
+        (429, "concurrency_limit_exceeded"),
+        (500, "provider_error"),
+    ],
+)
+def test_a_router_bucket_outranks_the_status_table_on_every_status(
+    status: int, bucket: str
+) -> None:
+    # The status table exists for responses that carry no bucket at all. A
+    # response that names one is Router speaking for itself, and letting the
+    # table win destroyed the bucket three ways on live traffic: 422
+    # `invalid_input` surfaced as `invalid_workflow`, 409s as `hash_mismatch`
+    # (killing the collect rule), and 403 `not_enabled` as `forbidden` -- so
+    # `except NotEnabled`, the one handler every pre-launch caller writes,
+    # never fired.
+    err = error_from_envelope(status, None, error_type=bucket, retry_after=3)
+    assert err.code == bucket
+    # The pace survives regardless of the code: `comfy_sdk.retry` keys the
+    # 429 branch on status + Retry-After, not on `queue_full`.
+    assert err.retry_after == 3
+
+
+def test_a_bucketless_429_still_means_queue_full() -> None:
+    # The workflow surface's own 429 carries no bucket; the status table is
+    # still what names it, exactly as before the generalization.
+    err = error_from_envelope(429, None, retry_after=3)
     assert err.code == "queue_full"
     assert isinstance(err, QueueFull)
-    # And the pace survives, which is what `comfy_sdk.retry` keys the 429 on.
     assert err.retry_after == 3
 
 
@@ -92,3 +115,46 @@ def test_a_body_that_names_no_bucket_still_falls_back_to_the_status(body: object
     # response diagnosable rather than replacing it with a decoding failure.
     err = error_from_envelope(401, body)  # type: ignore[arg-type]
     assert err.code == "unauthorized"
+
+
+# --- a preserved bucket becoming the typed RouterError ---
+#
+# Keeping the bucket as the `code` is only half the fix: `models.run` raises
+# through `to_sdk_error`, so the bucket must also select the RouterError
+# subclass there or `except NotEnabled` still catches nothing.
+
+
+@pytest.mark.parametrize(
+    ("bucket", "status", "cls_name"),
+    [
+        ("not_enabled", 403, "NotEnabled"),
+        ("invalid_input", 422, "InvalidInput"),
+        ("model_not_found", 404, "ModelNotFound"),
+        ("concurrency_limit_exceeded", 409, "ConcurrencyLimitExceeded"),
+        ("rate_limited", 429, "RateLimited"),
+        ("provider_error", 500, "ProviderError"),
+        ("deadline_exceeded", 504, "DeadlineExceeded"),
+    ],
+)
+def test_a_router_only_bucket_raises_its_typed_class(
+    bucket: str, status: int, cls_name: str
+) -> None:
+    import comfy_sdk.router_exceptions as rx
+
+    err = to_sdk_error(ApiError("router said no", code=bucket, http_status=status, retry_after=7))
+    assert type(err) is getattr(rx, cls_name)
+    assert err.code == bucket
+    assert err.http_status == status
+    assert err.retry_after == 7
+
+
+@pytest.mark.parametrize("code", ["unauthorized", "forbidden", "insufficient_credits"])
+def test_a_bucket_both_surfaces_spell_keeps_its_v2_class(code: str) -> None:
+    # These three codes are spelled identically by the v2 envelope and by
+    # Router, and the code string alone cannot say which surface answered.
+    # Retyping them to the RouterError twins would break every jobs-surface
+    # handler to fix none -- the v2 classes fire on the router surface too.
+    import comfy_sdk.exceptions as sdk
+
+    err = to_sdk_error(ApiError("no", code=code, http_status=403))
+    assert type(err) is getattr(sdk, "".join(p.title() for p in code.split("_")))


### PR DESCRIPTION
## Problem

A Router error response names its own bucket — the `X-Comfy-Error-Type` header, repeated as the body's top-level `error_type` — but the decoder only let that bucket through on `409` and on statuses the status table did not name. Everywhere else the table won and destroyed the bucket before anything downstream could read it:

- a `403` `not_enabled` surfaced as `Forbidden`, so `except NotEnabled` — the one handler every pre-launch caller writes — never fired (reproduced live: a not-yet-enabled account got `Forbidden` from `models.run`)
- a `422` `invalid_input` surfaced as `InvalidWorkflow` (a jobs-surface class), which is what every reachability probe tripped over
- a `404` `model_not_found` surfaced as plain `NotFound`

## Fix — two halves

**`comfy_low.errors`**: precedence is now envelope `error.code` → wire bucket when one is present → status table. Only responses that carry a bucket retype, and only Router sends one; the v2 envelope and bucket-less responses (including a bare `429` → `QueueFull`) decode exactly as before.

**`comfy_sdk.exceptions.to_sdk_error`**: a preserved router-only bucket now raises its typed `RouterError` subclass (`NotEnabled`, `InvalidInput`, `ModelNotFound`, `ConcurrencyLimitExceeded`, …) instead of a bare `ComfyError`. The three buckets both surfaces spell identically (`unauthorized`, `forbidden`, `insufficient_credits`) deliberately keep their v2 classes — the code string alone cannot say which surface answered, and those classes catch on both.

Retry pacing is keyed on status + `Retry-After` and is unchanged; the collect rule on `409` `concurrency_limit_exceeded` is unchanged.

## Tests

- Table-driven: the bucket survives on 403/404/409/422/429/500, with `Retry-After` intact
- Router-only buckets raise their typed classes across 7 statuses; overlapping buckets keep their v2 classes
- Bucket-less and v2-envelope decoding pinned unchanged
- One prior test asserting the old precedence (`429` + bucket → `queue_full`) is rewritten to the new invariant — that test encoded exactly the behavior this PR removes
- Full suite: 718 passed locally (ruff, mypy, format, hygiene all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)