### PR TITLE
docs(errors): attribute the detail[] validation shape to FastAPI

### DIFF
--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -97,7 +97,7 @@ def test_a_bucketless_429_still_means_queue_full() -> None:
 
 
 def test_a_router_validation_body_degrades_rather_than_coercing_its_detail() -> None:
-    # Router's per-field validation body is the fal/FastAPI `detail[]` shape. A
+    # Router's per-field validation body is the FastAPI `detail[]` shape. A
     # list is not a message: stringifying it would put a Python repr in front of
     # a caller, so the status-derived message answers instead.
     err = error_from_envelope(


### PR DESCRIPTION
## Summary

One comment change, no behaviour.

`tests/test_error_mapping.py` described Router's per-field validation body as the "fal/FastAPI `detail[]` shape". The `detail[]` body carrying `loc` / `msg` / `type` is FastAPI's own validation error format. Naming a specific third-party API next to it implied the shape originates there, which is both inaccurate and more than this SDK needs to say about where a wire format came from.

Dropping the vendor name leaves the attribution correct: this is the FastAPI shape, and Router happens to serve it.

## Verification

Comment-only. `tests/test_error_mapping.py` compiles and the assertions around it are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a test comment to accurately describe the FastAPI validation error format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->