### PR TITLE
docs: use the real bfl/flux-2-pro id in the model-run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,11 +400,11 @@ operations are added to this namespace as they land.
 ### `models.run` — one call, one result
 
 ```python
-result = client.models.run("fal-ai/flux-pro", {"prompt": "a cat", "steps": 4})
+result = client.models.run("bfl/flux-2-pro", {"prompt": "a cat", "steps": 4})
 result["images"][0]["url"]
 ```
 
-That call is `POST https://api.comfy.org/v2/models/fal-ai/flux-pro` with
+That call is `POST https://api.comfy.org/v2/models/bfl/flux-2-pro` with
 `{"prompt": "a cat", "steps": 4}` as the body.
 
 Three things follow from that, and they are the whole contract of this method:
@@ -413,8 +413,8 @@ Three things follow from that, and they are the whole contract of this method:
   `COMFY_ROUTER_BASE_URL`, not by `COMFY_BASE_URL`. Your API key goes with it.
 - **The first argument is the model's canonical id**, `{provider}/{model}` —
   exactly the two segments that address the route, and exactly what Router's
-  model catalog lists. It must be two non-empty segments: `"fal-ai"` alone,
-  `"fal-ai/flux-pro/fp8"` (the three-segment variant form, which this route does
+  model catalog lists. It must be two non-empty segments: `"bfl"` alone,
+  `"bfl/flux-2-pro/fp8"` (the three-segment variant form, which this route does
   not take yet), and anything containing a `.` or `..` segment all raise
   `ValueError` locally, before any request. A non-string raises `TypeError`.
 - **The second argument is the model's own native input**, forwarded to the
@@ -432,7 +432,7 @@ The awaitable form is the **async client**, not a differently-named method:
 
 ```python
 async with AsyncComfy(api_key="comfyui-...") as client:
-    result = await client.models.run("fal-ai/flux-pro", {"prompt": "a cat"})
+    result = await client.models.run("bfl/flux-2-pro", {"prompt": "a cat"})
 ```
 
 There is no `run_async()`, and there will not be one — one operation, one name,

--- a/spec/router-openapi.yaml
+++ b/spec/router-openapi.yaml
@@ -278,7 +278,7 @@ components:
       description: A canonical Comfy Router model ID, `{provider}/{model}` - exactly the value that addresses the model on `POST /v2/models/{provider}/{model}`, so a caller can interpolate it into that path without re-deriving it from anything. Its `pattern` is `RouterProviderSegment` and `RouterModelSegment` joined by a single `/`, and `maxLength` is their sum plus that separator.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*/[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 193
-      example: bfl/flux-2-pro
+      example: fal-ai/flux-pro
     RouterModelInput:
       type: object
       description: 'A partner model''s native JSON input document, forwarded to the provider as-is. Its concrete shape is owned by the partner rather than by Comfy, so this is an open object: Router does not narrow, rename, or re-envelope the fields. It is a named component (never an inline anonymous object) because ComfyUI''s spec-driven codegen needs a class to generate.'
@@ -337,7 +337,7 @@ components:
       description: Lowercase `model` segment of the canonical `{provider}/{model}[/{variant}]` model ID - the model to run within that provider. Shared by the invocation route's `model` path parameter and a catalog entry's `model` field, for the same no-drift reason as `RouterProviderSegment`.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 128
-      example: flux-2-pro
+      example: flux-pro
     RouterPageCursor:
       type: string
       description: 'An OPAQUE cursor into a Router list. It is produced by the server and only ever round-tripped: it is not an offset, not a model ID, not ordered, and not stable across catalog rebuilds, so parsing one, incrementing one, or persisting one beyond the walk it came from are all outside the contract. Cursor rather than offset because the catalog is a moving list - an offset walk silently skips or repeats entries when entries are added or removed mid-walk, and a caller cannot tell that it happened.'
@@ -350,7 +350,7 @@ components:
       description: Lowercase `provider` segment of the canonical `{provider}/{model}[/{variant}]` model ID - the partner whose model is being addressed. The invocation route's `provider` path parameter and a catalog entry's `provider` field both reference this one schema, which is what keeps the listed IDs and the accepted IDs from drifting apart.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 64
-      example: bfl
+      example: fal-ai
     RouterValidationErrorContext:
       type: object
       description: 'The violated bound for one `RouterValidationErrorDetail`, carried from the provider verbatim - for example `{"limit_value": 8}` alongside `greater_than`, `{"min_width": 512}` alongside `image_too_small`, or `{"max_size_bytes": 10485760}` alongside `file_too_large`. The key set is specific to the provider and the error type, so this is deliberately an open object: narrowing it to a fixed field list, or folding it into the `msg` string, is precisely how a ported integration compiles and then silently loses the branch that read the bound. Absent when the error type carries no bound.'

--- a/spec/router-openapi.yaml
+++ b/spec/router-openapi.yaml
@@ -278,7 +278,7 @@ components:
       description: A canonical Comfy Router model ID, `{provider}/{model}` - exactly the value that addresses the model on `POST /v2/models/{provider}/{model}`, so a caller can interpolate it into that path without re-deriving it from anything. Its `pattern` is `RouterProviderSegment` and `RouterModelSegment` joined by a single `/`, and `maxLength` is their sum plus that separator.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*/[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 193
-      example: fal-ai/flux-pro
+      example: bfl/flux-2-pro
     RouterModelInput:
       type: object
       description: 'A partner model''s native JSON input document, forwarded to the provider as-is. Its concrete shape is owned by the partner rather than by Comfy, so this is an open object: Router does not narrow, rename, or re-envelope the fields. It is a named component (never an inline anonymous object) because ComfyUI''s spec-driven codegen needs a class to generate.'
@@ -337,7 +337,7 @@ components:
       description: Lowercase `model` segment of the canonical `{provider}/{model}[/{variant}]` model ID - the model to run within that provider. Shared by the invocation route's `model` path parameter and a catalog entry's `model` field, for the same no-drift reason as `RouterProviderSegment`.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 128
-      example: flux-pro
+      example: flux-2-pro
     RouterPageCursor:
       type: string
       description: 'An OPAQUE cursor into a Router list. It is produced by the server and only ever round-tripped: it is not an offset, not a model ID, not ordered, and not stable across catalog rebuilds, so parsing one, incrementing one, or persisting one beyond the walk it came from are all outside the contract. Cursor rather than offset because the catalog is a moving list - an offset walk silently skips or repeats entries when entries are added or removed mid-walk, and a caller cannot tell that it happened.'
@@ -350,7 +350,7 @@ components:
       description: Lowercase `provider` segment of the canonical `{provider}/{model}[/{variant}]` model ID - the partner whose model is being addressed. The invocation route's `provider` path parameter and a catalog entry's `provider` field both reference this one schema, which is what keeps the listed IDs and the accepted IDs from drifting apart.
       pattern: ^[a-z0-9]+([._-][a-z0-9]+)*$
       maxLength: 64
-      example: fal-ai
+      example: bfl
     RouterValidationErrorContext:
       type: object
       description: 'The violated bound for one `RouterValidationErrorDetail`, carried from the provider verbatim - for example `{"limit_value": 8}` alongside `greater_than`, `{"min_width": 512}` alongside `image_too_small`, or `{"max_size_bytes": 10485760}` alongside `file_too_large`. The key set is specific to the provider and the error type, so this is deliberately an open object: narrowing it to a fixed field list, or folding it into the `msg` string, is precisely how a ported integration compiles and then silently loses the branch that read the bound. Absent when the error type carries no bound.'

--- a/tests/test_models_run.py
+++ b/tests/test_models_run.py
@@ -137,7 +137,7 @@ def test_the_sans_io_request_builder_agrees_with_the_wire() -> None:
         # `RouterModelSegment` pattern, and none of them is percent-encoded:
         # they are unreserved (or sub-delims) in a path segment, so the URL the
         # caller reads in a log is the id they passed.
-        ("fal-ai/flux-pro", "/v2/models/fal-ai/flux-pro"),
+        ("bfl/flux-2-pro", "/v2/models/bfl/flux-2-pro"),
         ("acme/sd_xl.turbo", "/v2/models/acme/sd_xl.turbo"),
         ("acme_labs/v1.5", "/v2/models/acme_labs/v1.5"),
         # ...while anything that would change the *structure* of the path is


### PR DESCRIPTION
## ELI-5

The README's very first Router example told you to run a model called `fal-ai/flux-pro`. That model does not exist, so the first line a new reader copy-pastes could never work. It is wrong twice over: `flux-pro` is not an enrolled Comfy Router model under any provider, and `fal-ai` is not a Comfy provider slug either — the fal provider's slug is `fal`, and `fal-ai` is the upstream path segment *inside* it. Flux is served direct from Black Forest Labs under `bfl/*`. This swaps the example for `bfl/flux-2-pro`, which is real, enrolled, and already the canonical id in the Router quickstart (picked there for a measured ~3.1s p50, the fastest path on the Router).

## What changed

Docs and one test fixture — nothing in `src/` moved, no generated artifact changed, no vendored file was touched, and `models.run` behaviour is untouched.

- `README.md` — the quickstart call, the `POST https://api.comfy.org/v2/models/...` prose, the id-format bullet (both its one-segment example and its three-segment variant example, now `"bfl"` and `"bfl/flux-2-pro/fp8"`), and the async-client example.
- `tests/test_models_run.py` — the percent-encoding fixture that used the bad id as a synthetic one, renamed to the real id.

## Why `spec/router-openapi.yaml` is *not* in this diff

An earlier revision of this PR also rewrote the three `example:` values the vendored Router spec carries (`RouterModelId`, `RouterModelSegment`, `RouterProviderSegment`). That was reverted in `9675e8e`, on review.

`spec/router-openapi.yaml` is a one-way vendored copy of the canonical Router contract, and both [`spec/README.md`](spec/README.md) ("do not hand-edit either file") and [`AGENTS.md`](AGENTS.md) ("Vendored, synced one-way. Never hand-edit.") say it is not this repo's to edit. Nothing in CI would have caught the edit either — `scripts/check_drift.py` and `tests/test_router_spec_contract.py` only compare `RouterErrorType.x-comfy-error-types`, not `example:` values — so the local copy would have diverged from upstream silently, then either been reverted by the next routine sync or read as phantom churn in a diff reviewers are meant to take as pure upstream change. Those three example values belong in the canonical contract; they should arrive here via a sync, not by hand.

The consequence is deliberate and visible: `fal-ai/flux-pro` still appears three times in `spec/router-openapi.yaml` on this branch. That is the vendored upstream's text, not this repo's prose.

## Sweep

The whole tree was swept for the string, not just the lines the ticket enumerated. It appeared on **9 lines across 3 files** (README 5, spec 3, tests 1). After this change it appears on **3 lines in 1 file** — the vendored spec, left untouched on purpose per the section above; **0 lines** in everything this repo authors. Nothing in `src/` carried it: the spec's `example:` values do not propagate into `src/comfy_low/models/_generated.py`, which is why the drift gate stays green with no regeneration.

## Why the test rename is safe

The renamed row's stated job is that `.`, `_` and `-` are legal inside a segment and are not percent-encoded. The old id carried `-` in both segments; `bfl/flux-2-pro` carries it only in the model segment. That is not a coverage loss: `model_run_request` applies the identical `quote(..., safe="")` to both segments, so provider-vs-model is not a distinct code path, and the sibling rows still cover `_` in a provider segment (`acme_labs/v1.5`) and `_`/`.` in a model segment (`acme/sd_xl.turbo`). The new id also exercises a digit-only inner segment (`2`), which the old one did not.

## Verifying the premise, not just the diff

This change rests on a non-existence claim, so it was checked against the catalog rather than from memory: on the platform's default branch today, every enrolled Flux route lives under the `bfl` provider — `flux-2-pro` among them, with an authored per-model input schema alongside it — and the `fal` provider carries no Flux route at all. The replacement id is also the one the platform's own Router quickstart uses.

## Residual

- **The upstream source of the spec examples is unfixed, and this PR now deliberately leaves the vendored copy carrying it.** `spec/router-openapi.yaml` is hand-synced, not generated, and the drift gate does not compare `example:` values — so the stale ids there redden no check and will not self-update. Verified today: the upstream spec still carries all three original `example:` values on its default branch. Fixing it in the canonical contract, and picking it up here via a normal sync, is the correct path and is tracked separately.
- **A second unrunnable README example is left unfixed.** `README.md:554` and `README.md:566` (the idempotency-replay example) call `client.models.run("acme/flux/dev", ...)`. That is a three-segment id, which `parse_model_id` refuses locally with `ValueError` before any request — the same string is the fixture for `test_a_three_segment_id_says_the_variant_is_not_addressable_yet`. It is a different defect (a malformed id shape, not a non-existent model) and outside this change's enumerated scope, but it is a second README example a reader cannot run. The fix is to collapse it to a two-segment id.
- **The same example is still live in 18 further files across 4 other repositories in the organisation** (a current org-wide code search; one further hit is an unrelated vendored third-party sample). Cross-repo work is out of scope for this PR; those are separately tracked.
- **Unexercised artifact — the live Router catalog.** `GET /v2/models/{provider}/{model}/openapi.json` requires authentication and answered `401 No Authorization header found` for every id probed, so the live surface could not discriminate a real id from a fake one here without a key this run does not hold. The verification above is against the platform's source of truth instead. Confirming `bfl/flux-2-pro` against the live catalog with a real key is a one-command check worth doing.
- **Unexercised artifact — the originating report.** The upstream discussion thread the report came from was not readable from this environment, and the report itself records that its exact wording was never verified. The linked parent issue's own body and comments were likewise not available, so the substitution here follows the replacement id the report names rather than anything read first-hand from either.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** re-run on the reverted tree (`9675e8e`) with the repo's pinned toolchain (`ruff~=0.15.22` via the `dev` extra) — `ruff check .`: all checks passed; `ruff format --check .`: 51 files already formatted; `mypy src`: no issues in 19 source files; `pytest -q`: 718 passed, 4 skipped; `scripts/check_public_repo_hygiene.py`: no internal-only references; `scripts/check_drift.py`: both Router checks OK (its `_check_models` step needs the codegen binary, absent from this local venv — CI's `comfy_low codegen drift` job covers it and passes). `git diff origin/main -- spec/router-openapi.yaml` is empty, confirming the vendored copy is byte-identical to `main`. Note the ambient `ruff` on this machine is 0.16.0, which also reformats Markdown and reports spurious README diffs against this repo.
- **Deviations:** the vendored-spec edits named in the original acceptance criteria were reverted rather than kept — see "Why `spec/router-openapi.yaml` is *not* in this diff". The remaining criteria are met; the items under Residual are out-of-scope findings and unexercisable artifacts, not skipped criteria.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `models.run` examples and validation descriptions to use the canonical `bfl/flux-2-pro` model identifier.
  - Updated API schema examples to reflect the `bfl/flux-2-pro` model path.

- **Tests**
  - Updated model routing checks to validate requests using the canonical model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->