### PR TITLE
feat: carry the Idempotency-Key on every exception submit() raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,33 @@ notes for each version.
 
 ### Added
 
-- Every exception `client.submit()` — and so `client.run()`, which submits
-  through it — raises **for a failed call** now carries the `Idempotency-Key`
-  it was made under, on `.idempotency_key`, matching `client.models.run()`:
-  the mapped `ComfyError` subclasses, a `QueueFull` raised once the 429 retry
-  budget is exhausted (the same key on every retried attempt), and a transport
-  failure with no response at all (a dropped connection, a read timeout), which
-  previously escaped `submit()` untranslated and now reads `.request_id` and
-  `.retry_after` as `None` rather than raising `AttributeError`. Cancelling an
-  in-flight `AsyncComfy.submit()` yields the key too, and the cancellation
-  still propagates unchanged. The semantics differ from `models.run`'s and the
-  difference matters: `POST /jobs` **rejects** a reused key with
+- Every exception a failed `POST /jobs` attempt inside `client.submit()`
+  raises — and so the submit phase of `client.run()` — now carries the
+  `Idempotency-Key` it was made under, on `.idempotency_key`, matching
+  `client.models.run()`: the mapped `ComfyError` subclasses, a `QueueFull`
+  raised once the 429 retry budget is exhausted (the same key on every retried
+  attempt), and a transport failure with no response at all (a dropped
+  connection, a read timeout), which previously escaped `submit()` untranslated
+  and now reads `.request_id` and `.retry_after` as `None` rather than raising
+  `AttributeError`. A failure raised before the request exists (a UI-format
+  workflow, an asset that would not upload) or while `run()` polls the job
+  afterwards carries none. Cancelling an in-flight `AsyncComfy.submit()`
+  (`task.cancel()`) yields the key too, and the cancellation still propagates
+  unchanged; an `asyncio.wait_for` timeout raises its own `TimeoutError`, which
+  does not. The semantics differ from `models.run`'s and the difference
+  matters: `POST /jobs` **rejects** a reused key with
   `422 idempotency_key_reuse` rather than replaying it, so the key on a
-  `submit()` error records what was sent — poll or list for the job the first
-  attempt may already have created — rather than being a replay handle to
-  resubmit under. Nothing about what is retried, what key is minted, or what
-  goes on the wire changed.
+  `submit()` error is the one this attempt was made under, not a replay handle:
+  after an ambiguous failure poll or list for the job the first attempt may
+  already have created; a failure the server never saw (a connect failure, an
+  exhausted `QueueFull`) leaves it unclaimed. Nothing about what is retried or
+  what goes on the wire changed.
+- `client.submit(idempotency_key=...)` now validates a caller-supplied key the
+  way `client.models.run()` does: an empty, over-long (> 255), or
+  non-printable-ASCII key raises `ValueError` locally, before any request.
+  Previously `""` fell into the mint-a-fresh-key branch — disabling the
+  caller's dedup and, with the stamp above, reporting a key the caller never
+  passed — and an invalid key failed at the transport after the round trip.
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the
   typed `RouterError` buckets, a `RouterError` whose `error_type` this version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ notes for each version.
 
 ### Added
 
+- Every exception `client.submit()` — and so `client.run()`, which submits
+  through it — raises **for a failed call** now carries the `Idempotency-Key`
+  it was made under, on `.idempotency_key`, matching `client.models.run()`:
+  the mapped `ComfyError` subclasses, a `QueueFull` raised once the 429 retry
+  budget is exhausted (the same key on every retried attempt), and a transport
+  failure with no response at all (a dropped connection, a read timeout), which
+  previously escaped `submit()` untranslated and now reads `.request_id` and
+  `.retry_after` as `None` rather than raising `AttributeError`. Cancelling an
+  in-flight `AsyncComfy.submit()` yields the key too, and the cancellation
+  still propagates unchanged. The semantics differ from `models.run`'s and the
+  difference matters: `POST /jobs` **rejects** a reused key with
+  `422 idempotency_key_reuse` rather than replaying it, so the key on a
+  `submit()` error records what was sent — poll or list for the job the first
+  attempt may already have created — rather than being a replay handle to
+  resubmit under. Nothing about what is retried, what key is minted, or what
+  goes on the wire changed.
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the
   typed `RouterError` buckets, a `RouterError` whose `error_type` this version

--- a/README.md
+++ b/README.md
@@ -584,22 +584,32 @@ Three attributes carry this:
 All three read as `None` rather than raising on any exception `models.run`
 raises, so a handler never has to guard the attribute access itself.
 
-`submit()` — and so `run()`, which submits through it — stamps the key too, but
-what the key is *good for* differs, so read it with the surface in mind.
-`models.run` sends it to a surface that **replays** a claimed key, which is what
-makes it a handle on a generation you were already billed for. `POST /jobs`
-instead **rejects** a reused key with `422 idempotency_key_reuse` (see the
+`submit()` stamps the key too — on every failure of the `POST /jobs` attempt
+itself, and so on the submit phase of `run()`. A failure raised before the
+request exists (a UI-format workflow, an asset that would not upload) or while
+`run()` polls the job afterwards carries none. What the key is *good for*
+differs, so read it with the surface in mind. `models.run` sends it to a
+surface that **replays** a claimed key, which is what makes it a handle on a
+generation you were already billed for. `POST /jobs` instead **rejects** a
+reused key with `422 idempotency_key_reuse` (see the
 [`IdempotencyKeyReuse`](#typed-errors) bullet below): keys there are single-use
-and there is no replay. So on a `submit()` failure `exc.idempotency_key` tells
-you a key *was* sent — do not resubmit blindly under it, poll or list for the
-job the first attempt may already have created.
+and there is no replay. So on a `submit()` failure `exc.idempotency_key` is the
+key this attempt was made under, not a replay handle. Whether the server ever
+saw it depends on the failure: a connect failure never delivered it, and an
+exhausted `QueueFull` was refused on every attempt, so the key is unclaimed and
+resubmitting under it is fine. After an ambiguous failure — a read timeout, a
+connection dropped mid-request — poll or list for the job the first attempt may
+already have created rather than resubmitting under it.
 
-`idempotency_key` is still `None` on errors from every other surface — one that
-sends no key, and an asset upload, which mints a key per handle without
-recording it. So `None` means "this SDK did not record a key for you", **not**
-"no key was sent, resend freely": check for it before replaying, as the snippet above
-does, rather than passing it straight back into `idempotency_key=` where `None`
-means "mint a fresh one" and starts a second billed generation.
+`idempotency_key` reads as `None` on every `ComfyError` from other surfaces —
+one that sends no key, and an asset upload, which mints a key per handle without
+recording it. A raw `httpx` error from one of those key-free calls is re-raised
+untouched and does not carry the attribute at all, so a handler that spans
+surfaces reads it with `getattr(exc, "idempotency_key", None)`. Either way
+`None` means "this SDK did not record a key for you", **not** "no key was sent,
+resend freely": check for it before replaying, as the snippet above does, rather
+than passing it straight back into `idempotency_key=` where `None` means "mint a
+fresh one" and starts a second billed generation.
 
 ## Sync and async
 

--- a/README.md
+++ b/README.md
@@ -584,12 +584,22 @@ Three attributes carry this:
 All three read as `None` rather than raising on any exception `models.run`
 raises, so a handler never has to guard the attribute access itself.
 
-`idempotency_key` is `None` on errors from *other* surfaces, though — it is
-`models.run` that records it, and `submit()` sends a key without stamping one.
-So `None` means "this SDK did not record a key for you", **not** "no key was
-sent, resend freely": check for it before replaying, as the snippet above does,
-rather than passing it straight back into `idempotency_key=` where `None` means
-"mint a fresh one" and starts a second billed generation.
+`submit()` — and so `run()`, which submits through it — stamps the key too, but
+what the key is *good for* differs, so read it with the surface in mind.
+`models.run` sends it to a surface that **replays** a claimed key, which is what
+makes it a handle on a generation you were already billed for. `POST /jobs`
+instead **rejects** a reused key with `422 idempotency_key_reuse` (see the
+[`IdempotencyKeyReuse`](#typed-errors) bullet below): keys there are single-use
+and there is no replay. So on a `submit()` failure `exc.idempotency_key` tells
+you a key *was* sent — do not resubmit blindly under it, poll or list for the
+job the first attempt may already have created.
+
+`idempotency_key` is still `None` on errors from every other surface — one that
+sends no key, and an asset upload, which mints a key per handle without
+recording it. So `None` means "this SDK did not record a key for you", **not**
+"no key was sent, resend freely": check for it before replaying, as the snippet above
+does, rather than passing it straight back into `idempotency_key=` where `None`
+means "mint a fresh one" and starts a second billed generation.
 
 ## Sync and async
 

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -310,13 +310,25 @@ class Comfy:
         reused key is *rejected*, not replayed: on reuse, catch the error and
         poll/list for the job the first attempt already created.
 
-        Every exception a failed submit raises carries the key it was made
-        under on ``.idempotency_key`` — including a transport failure that
-        never reached a response (``httpx.ConnectError``, a read timeout),
-        which reads ``.request_id`` and ``.retry_after`` as ``None`` rather
-        than raising. Because a reused key is rejected rather than replayed,
-        that key is a record of what was sent, not a replay handle: use it to
-        go looking for the job, not to resubmit.
+        A caller-supplied ``idempotency_key`` is validated the way
+        ``models.run`` validates its own — an empty, over-long, or
+        non-printable-ASCII key raises ``ValueError`` here, before any request
+        — so an explicit ``""`` never silently mints a fresh key.
+
+        Every exception the ``POST /jobs`` attempt itself raises carries the
+        key it was made under on ``.idempotency_key``: the mapped
+        ``ComfyError``, a ``QueueFull`` once the retry budget is spent, and a
+        transport failure that never reached a response (``httpx.ConnectError``,
+        a read timeout), which reads ``.request_id`` and ``.retry_after`` as
+        ``None`` rather than raising. A failure raised before the request
+        exists — a UI-format workflow, an asset that would not upload — carries
+        none. Because a reused key is rejected rather than replayed, the key is
+        not a replay handle. Whether the server ever saw it depends on the
+        failure: a connect failure never delivered it and a ``QueueFull`` was
+        refused on every attempt, so the key is unclaimed and resubmitting
+        under it is fine; after an ambiguous failure (a read timeout, a
+        connection dropped mid-request) poll or list for the job the first
+        attempt may already have created rather than resubmitting under it.
 
         ``api_key`` authenticates partner (API) nodes embedded in the workflow
         (e.g. Gemini) — unrelated to idempotency and unrelated to the bearer
@@ -325,8 +337,14 @@ class Comfy:
         only when supplied; omitted from the request entirely otherwise.
         """
         _guard_ui_format(workflow)
+        # Validated before any bytes move, like `models.run`: `""` used to
+        # fall into the mint-a-fresh-key branch and disable the caller's dedup.
+        key = (
+            _core.validate_idempotency_key(idempotency_key)
+            if idempotency_key is not None
+            else _core.new_idempotency_key()
+        )
         graph = self._materialize(workflow)
-        key = idempotency_key or _core.new_idempotency_key()
         extra_data = _core.extra_data_for(api_key)
         deadline = _now() + _QUEUE_RETRY_BUDGET
         # The key is a local of this frame, so anything that propagates past
@@ -436,8 +454,12 @@ class AsyncComfy:
         import asyncio
 
         _guard_ui_format(workflow)
+        key = (
+            _core.validate_idempotency_key(idempotency_key)
+            if idempotency_key is not None
+            else _core.new_idempotency_key()
+        )
         graph = await self._materialize(workflow)
-        key = idempotency_key or _core.new_idempotency_key()
         extra_data = _core.extra_data_for(api_key)
         deadline = _now() + _QUEUE_RETRY_BUDGET
         # See :meth:`Comfy.submit` — same stamp, and here it also rides out on

--- a/src/comfy_sdk/client.py
+++ b/src/comfy_sdk/client.py
@@ -48,7 +48,7 @@ from comfy_low.transport import ROUTER_BASE_URL, AsyncComfyLow, ComfyLow, origin
 
 from . import _core
 from .assets import AssetFactory, AsyncAssetFactory
-from .exceptions import MissingApiKey, WorkflowFormatUi, to_sdk_error
+from .exceptions import MissingApiKey, WorkflowFormatUi, to_sdk_error, translating
 from .jobs import AsyncJob, AsyncJobFactory, Job, JobFactory
 from .models import AsyncModels, Models
 from .retry import DEFAULT_RETRY, RetryPolicy
@@ -310,6 +310,14 @@ class Comfy:
         reused key is *rejected*, not replayed: on reuse, catch the error and
         poll/list for the job the first attempt already created.
 
+        Every exception a failed submit raises carries the key it was made
+        under on ``.idempotency_key`` — including a transport failure that
+        never reached a response (``httpx.ConnectError``, a read timeout),
+        which reads ``.request_id`` and ``.retry_after`` as ``None`` rather
+        than raising. Because a reused key is rejected rather than replayed,
+        that key is a record of what was sent, not a replay handle: use it to
+        go looking for the job, not to resubmit.
+
         ``api_key`` authenticates partner (API) nodes embedded in the workflow
         (e.g. Gemini) — unrelated to idempotency and unrelated to the bearer
         token this client was constructed with. It is never persisted or
@@ -321,17 +329,23 @@ class Comfy:
         key = idempotency_key or _core.new_idempotency_key()
         extra_data = _core.extra_data_for(api_key)
         deadline = _now() + _QUEUE_RETRY_BUDGET
-        while True:
-            try:
-                model = self._low.post_jobs(graph, idempotency_key=key, extra_data=extra_data)
-                return Job(self._low, model)
-            except ApiError as exc:
-                err = to_sdk_error(exc)
-                delay = _retry_delay(exc, deadline)
-                if delay is None:
-                    raise err from exc
-                time.sleep(delay)
-                continue
+        # The key is a local of this frame, so anything that propagates past
+        # here takes the caller's only record of what was sent with it. The
+        # inner handler still owns what is retried and what surfaces; this
+        # stamps the key onto whatever it lets out — including a transport
+        # failure that never reached a response to translate.
+        with translating(idempotency_key=key):
+            while True:
+                try:
+                    model = self._low.post_jobs(graph, idempotency_key=key, extra_data=extra_data)
+                    return Job(self._low, model)
+                except ApiError as exc:
+                    err = to_sdk_error(exc)
+                    delay = _retry_delay(exc, deadline)
+                    if delay is None:
+                        raise err from exc
+                    time.sleep(delay)
+                    continue
 
     def run(
         self,
@@ -426,17 +440,22 @@ class AsyncComfy:
         key = idempotency_key or _core.new_idempotency_key()
         extra_data = _core.extra_data_for(api_key)
         deadline = _now() + _QUEUE_RETRY_BUDGET
-        while True:
-            try:
-                model = await self._low.post_jobs(graph, idempotency_key=key, extra_data=extra_data)
-                return AsyncJob(self._low, model)
-            except ApiError as exc:
-                err = to_sdk_error(exc)
-                delay = _retry_delay(exc, deadline)
-                if delay is None:
-                    raise err from exc
-                await asyncio.sleep(delay)
-                continue
+        # See :meth:`Comfy.submit` — same stamp, and here it also rides out on
+        # the cancellation of an in-flight `post_jobs`.
+        with translating(idempotency_key=key):
+            while True:
+                try:
+                    model = await self._low.post_jobs(
+                        graph, idempotency_key=key, extra_data=extra_data
+                    )
+                    return AsyncJob(self._low, model)
+                except ApiError as exc:
+                    err = to_sdk_error(exc)
+                    delay = _retry_delay(exc, deadline)
+                    if delay is None:
+                        raise err from exc
+                    await asyncio.sleep(delay)
+                    continue
 
     async def run(
         self,

--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -25,21 +25,27 @@ class ComfyError(Exception):
     #: The ``Idempotency-Key`` the failed call was made under. Populated by
     #: :meth:`comfy_sdk.models.Models.run` and its async twin, and by
     #: :meth:`comfy_sdk.client.Comfy.submit` /
-    #: :meth:`comfy_sdk.client.AsyncComfy.submit` — and therefore by
-    #: ``Comfy.run`` / ``AsyncComfy.run``, which submit through them. It is
-    #: ``None`` everywhere else: on an operation that sends no key, on an
-    #: asset upload (which mints a key per handle and does not record it), and
-    #: on an exception constructed by hand. So ``None`` means "this SDK did not
-    #: record a key for you", never "no key reached the server": do not infer
-    #: from it that a resend is safe.
+    #: :meth:`comfy_sdk.client.AsyncComfy.submit` on every failure of the
+    #: ``POST /jobs`` attempt itself — and so by the submit phase of
+    #: ``Comfy.run`` / ``AsyncComfy.run``. A failure while ``run`` polls the
+    #: job afterwards (a ``JobFailed``, a wait timeout) carries none: by then
+    #: the job exists and its id is the handle. It is ``None`` everywhere
+    #: else: on an operation that sends no key, on an asset upload (which
+    #: mints a key per handle and does not record it), and on an exception
+    #: constructed by hand. So ``None`` means "this SDK did not record a key
+    #: for you", never "no key reached the server": do not infer from it that
+    #: a resend is safe.
     #:
     #: What the key is *good for* differs by surface, so read it with the
     #: operation in mind: ``models.run`` sends it to a surface that replays a
     #: claimed key, so the key is a handle on the generation you were already
     #: billed for. ``POST /jobs`` instead *rejects* a reused key with
-    #: ``422 idempotency_key_reuse``, so on a ``submit`` failure the key says a
-    #: key was sent — poll or list for the job the first attempt may have
-    #: created rather than resubmitting under it.
+    #: ``422 idempotency_key_reuse``, so on a ``submit`` failure the key is the
+    #: one this attempt was made under, not a replay handle: after an
+    #: ambiguous failure poll or list for the job the first attempt may have
+    #: created rather than resubmitting under it, while a failure the server
+    #: never saw (a connect failure, an exhausted ``QueueFull``) leaves the key
+    #: unclaimed.
     #:
     #: Declared on the base rather than set per subclass so that a bucket this
     #: SDK version has never heard of — which arrives as a bare

--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -23,12 +23,23 @@ class ComfyError(Exception):
     """Base for every SDK-level error."""
 
     #: The ``Idempotency-Key`` the failed call was made under. Populated by
-    #: :meth:`comfy_sdk.models.Models.run` and its async twin, which are the
-    #: operations that pass a key to :func:`translating`; ``None`` everywhere
-    #: else — including on operations that *do* send a key but do not stamp it
-    #: (``Comfy.submit()``), and on an exception constructed by hand. So
-    #: ``None`` means "this SDK did not record a key for you", never "no key
-    #: reached the server": do not infer from it that a resend is safe.
+    #: :meth:`comfy_sdk.models.Models.run` and its async twin, and by
+    #: :meth:`comfy_sdk.client.Comfy.submit` /
+    #: :meth:`comfy_sdk.client.AsyncComfy.submit` — and therefore by
+    #: ``Comfy.run`` / ``AsyncComfy.run``, which submit through them. It is
+    #: ``None`` everywhere else: on an operation that sends no key, on an
+    #: asset upload (which mints a key per handle and does not record it), and
+    #: on an exception constructed by hand. So ``None`` means "this SDK did not
+    #: record a key for you", never "no key reached the server": do not infer
+    #: from it that a resend is safe.
+    #:
+    #: What the key is *good for* differs by surface, so read it with the
+    #: operation in mind: ``models.run`` sends it to a surface that replays a
+    #: claimed key, so the key is a handle on the generation you were already
+    #: billed for. ``POST /jobs`` instead *rejects* a reused key with
+    #: ``422 idempotency_key_reuse``, so on a ``submit`` failure the key says a
+    #: key was sent — poll or list for the job the first attempt may have
+    #: created rather than resubmitting under it.
     #:
     #: Declared on the base rather than set per subclass so that a bucket this
     #: SDK version has never heard of — which arrives as a bare

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,11 @@ class ServerState:
     # Idempotency-Key -> job id of the first (accepted) request, so a reuse of
     # the same key can be detected and rejected (single-use, no replay).
     idempotency: dict[str, str] = field(default_factory=dict)
+    # Every Idempotency-Key seen on POST /jobs, in arrival order (`None`
+    # records a submit that arrived without the header at all). Distinct from
+    # `idempotency`, which only records the keys an *accepted* request claimed
+    # — a test about a failed submit needs the key the server actually saw.
+    jobs_idempotency_keys: list[str | None] = field(default_factory=list)
     # Raw bytes of the last POST /assets multipart body (so tests can inspect
     # the parts actually sent — e.g. how many `tags` fields were included).
     last_upload_body: bytes = b""
@@ -660,6 +665,7 @@ def _make_handler(state: ServerState):
             state.last_workflow = body.get("workflow")
             state.last_jobs_body = body
             key = self.headers.get("Idempotency-Key")
+            state.jobs_idempotency_keys.append(key)
 
             if key and key in state.idempotency:
                 # Reject-on-duplicate (single-use keys, no replay): any reuse of

--- a/tests/test_client_submit_idempotency.py
+++ b/tests/test_client_submit_idempotency.py
@@ -38,7 +38,14 @@ def _wf(client: Comfy | AsyncComfy):
 
 
 def _closed_port() -> int:
-    """A port nothing is listening on — bound, read, then released."""
+    """A port nothing is listening on — bound, read, then released.
+
+    Released rather than held: holding the socket bound-but-not-listening
+    would close the tiny window in which something else could take the port,
+    but a SYN to such a port is *dropped* on macOS rather than refused, so the
+    connect runs to ``ConnectTimeout`` instead of the ``ConnectError`` these
+    tests are about. The window between release and connect is the price.
+    """
     with socket.socket() as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
@@ -107,6 +114,25 @@ async def test_a_caller_supplied_key_round_trips_on_the_async_client(server) -> 
     assert server.state.jobs_idempotency_keys == ["abc-async"]
 
 
+def test_an_empty_caller_key_is_refused_before_any_request(server) -> None:
+    # `""` used to fall into the mint-a-fresh-key branch: the caller's dedup
+    # silently disabled, and the exception then reporting a key the caller
+    # never passed. Validated like `models.run`'s key, before any bytes move.
+    with Comfy() as client:
+        with pytest.raises(ValueError, match="must not be empty"):
+            client.submit(_wf(client), idempotency_key="")
+    assert server.state.jobs_idempotency_keys == []
+
+
+async def test_an_invalid_caller_key_is_refused_before_any_async_request(server) -> None:
+    async with AsyncComfy() as client:
+        with pytest.raises(ValueError, match="must not be empty"):
+            await client.submit(_wf(client), idempotency_key="")
+        with pytest.raises(ValueError, match="printable ASCII"):
+            await client.submit(_wf(client), idempotency_key="bad\r\nkey")
+    assert server.state.jobs_idempotency_keys == []
+
+
 # --- the retried paths: one key across every attempt ----------------------
 
 
@@ -139,6 +165,7 @@ async def test_an_exhausted_async_queue_full_budget_carries_the_retried_key(
     sent = server.state.jobs_idempotency_keys
     assert len(sent) > 1
     assert set(sent) == {excinfo.value.idempotency_key}
+    assert excinfo.value.idempotency_key is not None
 
 
 # --- reject-not-replay: the key that was refused --------------------------
@@ -230,10 +257,12 @@ async def test_async_run_surfaces_the_key_of_a_failed_submit_phase(server) -> No
 
 
 async def test_cancelling_an_in_flight_submit_still_yields_the_key(server) -> None:
-    # A submit cancelled mid-flight — what `asyncio.wait_for` around it does —
+    # A submit cancelled mid-flight — `task.cancel()` on the task awaiting it —
     # may already have reached the server and created a job, so the key is the
     # caller's only record of what to look for. The cancellation itself must
-    # still propagate: it is re-raised bare, never converted.
+    # still propagate: it is re-raised bare, never converted. (An
+    # `asyncio.wait_for` timeout is a different exit: it swallows the inner
+    # cancellation and raises its own `TimeoutError`, which carries no key.)
     seen: list[str | None] = []
 
     async def _cancelled_post_jobs(

--- a/tests/test_client_submit_idempotency.py
+++ b/tests/test_client_submit_idempotency.py
@@ -1,0 +1,252 @@
+"""``submit()`` stamps its ``Idempotency-Key`` onto whatever it raises.
+
+``Comfy.submit`` / ``AsyncComfy.submit`` mint a key per call and send it on
+``POST /jobs``. Until now that key was a local of the submitting frame, so it
+died with any exception the call raised — and the caller of an auto-minted
+submit had no record of what had been sent. These tests pin the same contract
+``tests/test_models_run.py`` pins for ``models.run``: every failure of the call
+carries ``.idempotency_key``, including a transport failure that never reached
+a response and a cancellation of an in-flight submit.
+
+The semantics differ from ``models.run``'s and the difference is deliberate:
+``POST /jobs`` *rejects* a reused key (``422 idempotency_key_reuse``) rather
+than replaying it, so this key is a record of what was sent — poll or list for
+the job the first attempt may have created — not a replay handle.
+
+Everything here runs against the stubbed server in ``conftest.py``, except the
+two cases a listening server cannot produce (a connect failure, a cancellation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import httpx
+import pytest
+
+import comfy_sdk.client as _client_module
+from comfy_sdk import AsyncComfy, Comfy, ComfyError, IdempotencyKeyReuse, QueueFull
+from comfy_sdk.client import BASE_URL_ENV_VAR
+
+_GRAPH = {"3": {"class_type": "KSampler", "inputs": {}}}
+
+
+def _wf(client: Comfy | AsyncComfy):
+    return client.workflows.from_json(_GRAPH)
+
+
+def _closed_port() -> int:
+    """A port nothing is listening on — bound, read, then released."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _StepClock:
+    """A monotonic clock that advances a fixed step per read.
+
+    The queue-full budget is spent by *reads* rather than by wall time, so
+    "the budget ran out after N attempts" is exact instead of a race against a
+    loaded machine.
+    """
+
+    def __init__(self, step: float = 1.0) -> None:
+        self._t = 0.0
+        self._step = step
+
+    def __call__(self) -> float:
+        now = self._t
+        self._t += self._step
+        return now
+
+
+# --- the auto-minted key, which the caller never saw ----------------------
+
+
+def test_a_failed_submit_exposes_the_exact_auto_minted_key(server) -> None:
+    # An unmapped code, so this lands on the base `ComfyError` — the stamp has
+    # to reach it, not only the typed subclasses.
+    server.state.job_error = (422, "validation_error")
+    with Comfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            client.submit(_wf(client))
+    (sent,) = server.state.jobs_idempotency_keys
+    assert sent is not None
+    # The exact key the server received, not merely "a key": truthiness would
+    # pass on a freshly minted one, which records nothing about what was sent.
+    assert excinfo.value.idempotency_key == sent
+
+
+async def test_a_failed_async_submit_exposes_the_exact_auto_minted_key(server) -> None:
+    server.state.job_error = (422, "validation_error")
+    async with AsyncComfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            await client.submit(_wf(client))
+    (sent,) = server.state.jobs_idempotency_keys
+    assert sent is not None
+    assert excinfo.value.idempotency_key == sent
+
+
+def test_a_caller_supplied_key_round_trips_onto_the_exception(server) -> None:
+    server.state.job_error = (422, "validation_error")
+    with Comfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            client.submit(_wf(client), idempotency_key="abc")
+    assert excinfo.value.idempotency_key == "abc"
+    assert server.state.jobs_idempotency_keys == ["abc"]
+
+
+async def test_a_caller_supplied_key_round_trips_on_the_async_client(server) -> None:
+    server.state.job_error = (422, "validation_error")
+    async with AsyncComfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            await client.submit(_wf(client), idempotency_key="abc-async")
+    assert excinfo.value.idempotency_key == "abc-async"
+    assert server.state.jobs_idempotency_keys == ["abc-async"]
+
+
+# --- the retried paths: one key across every attempt ----------------------
+
+
+def test_an_exhausted_queue_full_budget_carries_the_retried_key(server, monkeypatch) -> None:
+    # The server never clears backpressure, so the retry loop runs to the end
+    # of its budget and surfaces `QueueFull`. That exception has to carry the
+    # key — and it must be the *same* key every attempt was made under, not a
+    # fresh one minted somewhere along the way.
+    server.state.queue_full_times = 1_000_000
+    monkeypatch.setattr(_client_module, "_now", _StepClock())
+    monkeypatch.setattr(_client_module, "_QUEUE_RETRY_BUDGET", 3.0)
+    with Comfy() as client:
+        with pytest.raises(QueueFull) as excinfo:
+            client.submit(_wf(client))
+    sent = server.state.jobs_idempotency_keys
+    assert len(sent) > 1
+    assert set(sent) == {excinfo.value.idempotency_key}
+    assert excinfo.value.idempotency_key is not None
+
+
+async def test_an_exhausted_async_queue_full_budget_carries_the_retried_key(
+    server, monkeypatch
+) -> None:
+    server.state.queue_full_times = 1_000_000
+    monkeypatch.setattr(_client_module, "_now", _StepClock())
+    monkeypatch.setattr(_client_module, "_QUEUE_RETRY_BUDGET", 3.0)
+    async with AsyncComfy() as client:
+        with pytest.raises(QueueFull) as excinfo:
+            await client.submit(_wf(client))
+    sent = server.state.jobs_idempotency_keys
+    assert len(sent) > 1
+    assert set(sent) == {excinfo.value.idempotency_key}
+
+
+# --- reject-not-replay: the key that was refused --------------------------
+
+
+def test_a_rejected_reused_key_is_the_key_on_the_exception(server) -> None:
+    # `POST /jobs` keys are single-use: the second call under the same key is
+    # refused rather than replayed. The exception names the key that was
+    # rejected, which is what a caller polls or lists for the first job by.
+    with Comfy() as client:
+        client.submit(_wf(client), idempotency_key="reused-01")
+        with pytest.raises(IdempotencyKeyReuse) as excinfo:
+            client.submit(_wf(client), idempotency_key="reused-01")
+    assert excinfo.value.idempotency_key == "reused-01"
+    assert server.state.jobs_idempotency_keys == ["reused-01", "reused-01"]
+
+
+async def test_a_rejected_reused_key_is_the_key_on_the_async_exception(server) -> None:
+    async with AsyncComfy() as client:
+        await client.submit(_wf(client), idempotency_key="reused-02")
+        with pytest.raises(IdempotencyKeyReuse) as excinfo:
+            await client.submit(_wf(client), idempotency_key="reused-02")
+    assert excinfo.value.idempotency_key == "reused-02"
+
+
+# --- no response at all: the case the key is most needed on ---------------
+
+
+def test_a_transport_level_failure_carries_the_key(monkeypatch) -> None:
+    # Nothing to translate — no response reached the client — so before this
+    # the httpx error escaped `submit()` untouched and the caller was left with
+    # a request that may or may not have created a job and no key to look for
+    # it by.
+    monkeypatch.setenv(BASE_URL_ENV_VAR, f"http://127.0.0.1:{_closed_port()}")
+    with Comfy() as client:
+        with pytest.raises(httpx.ConnectError) as excinfo:
+            client.submit(_wf(client))
+    assert excinfo.value.idempotency_key is not None  # type: ignore[attr-defined]
+    # The documented trio has to *read* rather than raise on exactly the
+    # failures it is most needed on: httpx's classes declare neither attribute.
+    assert excinfo.value.request_id is None  # type: ignore[attr-defined]
+    assert excinfo.value.retry_after is None  # type: ignore[attr-defined]
+
+
+async def test_an_async_transport_level_failure_carries_the_key(monkeypatch) -> None:
+    monkeypatch.setenv(BASE_URL_ENV_VAR, f"http://127.0.0.1:{_closed_port()}")
+    async with AsyncComfy() as client:
+        with pytest.raises(httpx.ConnectError) as excinfo:
+            await client.submit(_wf(client))
+    assert excinfo.value.idempotency_key is not None  # type: ignore[attr-defined]
+    assert excinfo.value.request_id is None  # type: ignore[attr-defined]
+    assert excinfo.value.retry_after is None  # type: ignore[attr-defined]
+
+
+def test_a_caller_supplied_key_survives_a_transport_failure(monkeypatch) -> None:
+    monkeypatch.setenv(BASE_URL_ENV_VAR, f"http://127.0.0.1:{_closed_port()}")
+    with Comfy() as client:
+        with pytest.raises(httpx.ConnectError) as excinfo:
+            client.submit(_wf(client), idempotency_key="abc-transport")
+    assert excinfo.value.idempotency_key == "abc-transport"  # type: ignore[attr-defined]
+
+
+# --- run(), which submits through submit() --------------------------------
+
+
+def test_run_surfaces_the_key_of_a_failed_submit_phase(server) -> None:
+    # `run` mints no key of its own — it calls `submit`, so the stamp has to
+    # reach the caller through it.
+    server.state.job_error = (422, "invalid_workflow")
+    with Comfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            client.run(_wf(client))
+    (sent,) = server.state.jobs_idempotency_keys
+    assert sent is not None
+    assert excinfo.value.idempotency_key == sent
+
+
+async def test_async_run_surfaces_the_key_of_a_failed_submit_phase(server) -> None:
+    server.state.job_error = (422, "invalid_workflow")
+    async with AsyncComfy() as client:
+        with pytest.raises(ComfyError) as excinfo:
+            await client.run(_wf(client))
+    (sent,) = server.state.jobs_idempotency_keys
+    assert sent is not None
+    assert excinfo.value.idempotency_key == sent
+
+
+# --- cancellation, the one BaseException the key rides out on -------------
+
+
+async def test_cancelling_an_in_flight_submit_still_yields_the_key(server) -> None:
+    # A submit cancelled mid-flight — what `asyncio.wait_for` around it does —
+    # may already have reached the server and created a job, so the key is the
+    # caller's only record of what to look for. The cancellation itself must
+    # still propagate: it is re-raised bare, never converted.
+    seen: list[str | None] = []
+
+    async def _cancelled_post_jobs(
+        graph: dict[str, Any], *, idempotency_key: str | None = None, **kw: Any
+    ) -> Any:
+        seen.append(idempotency_key)
+        raise asyncio.CancelledError
+
+    async with AsyncComfy() as client:
+        wf = _wf(client)
+        client._low.post_jobs = _cancelled_post_jobs  # type: ignore[method-assign]
+        with pytest.raises(asyncio.CancelledError) as excinfo:
+            await client.submit(wf)
+    assert seen == [excinfo.value.idempotency_key]  # type: ignore[attr-defined]
+    assert excinfo.value.idempotency_key is not None  # type: ignore[attr-defined]
+    assert excinfo.value.request_id is None  # type: ignore[attr-defined]


### PR DESCRIPTION
## ELI-5

`submit()` puts a one-time ticket number on every job it sends, so the server can refuse an accidental duplicate. If the send blew up, that number vanished with the error — and if `submit()` had minted it for you, you never saw it at all, so you couldn't go look up whether a job had been created. Now the ticket number rides out on the exception, exactly as it already does for `client.models.run()`.

## What changed

`Comfy.submit` / `AsyncComfy.submit` wrap their `while True:` retry loop in `translating(idempotency_key=key)` — the same boundary `models.run` has used since #97. That is the whole product change.

- The inner `except ApiError` handler is untouched: it still converts, still consults `_retry_delay`, still `time.sleep` / `await asyncio.sleep`s and retries. The outer context manager only *stamps* what the inner handler lets out (a `ComfyError` re-raised bare through `translating`'s `_STAMPABLE` branch).
- A transport failure (`httpx.HTTPError`) previously escaped `submit()` untranslated. It now carries `.idempotency_key`, and `.request_id` / `.retry_after` default to `None` on it rather than raising `AttributeError` — the documented trio finally reads uniformly on the failure it is most needed on.
- Cancelling an in-flight `AsyncComfy.submit()` carries the key too, and still propagates bare (same contract as `AsyncModels.run`).
- `Comfy.run` / `AsyncComfy.run` inherit it for free: they submit through `submit`.
- Key minting (`key = idempotency_key or _core.new_idempotency_key()`), what is retried, and the bytes on the wire are all unchanged.

**The semantic difference is documented, not glossed.** `models.run` sends its key to a surface that *replays* a claimed key, which is what makes that key a handle on a generation you were already billed for. `POST /jobs` instead *rejects* a reused key with `422 idempotency_key_reuse` — `spec/openapi.yaml:645`: "Single-use: the first request to present a key is processed; any later request with the same key is rejected `422` `idempotency_key_reuse` (reject-on-duplicate, no response replay)", against `spec/router-openapi.yaml:102`, where a replayed response "carries `Idempotent-Replayed: true` and is not charged a second time". So on a `submit()` error the key tells you a key *was* sent: poll or list for the job the first attempt may have created, rather than resubmitting under it. The README paragraph says exactly that and cross-references the existing `IdempotencyKeyReuse` bullet; `ComfyError.idempotency_key`'s docstring and the `CHANGELOG` entry carry the same distinction.

## Tests

New module `tests/test_client_submit_idempotency.py` (14 tests, sync and async throughout), mirroring the stamping tests in `tests/test_models_run.py` against the `POST /jobs` stub:

1. Auto-minted key on a non-retryable error (`422 validation_error`, deliberately an *unmapped* code so the stamp is proven on the base `ComfyError`) equals the header the server actually received.
2. A caller-supplied `idempotency_key="abc"` round-trips onto the exception and onto the wire.
3. Queue-full budget exhaustion: the `QueueFull` carries the key, and it is the *same* key on every retried request.
4. `422 idempotency_key_reuse` — driven by really reusing a key against the stub, not by a stubbed envelope — carries the key that was rejected.
5. Transport failure against a closed port: `httpx.ConnectError` carries the key and reads `.request_id is None`, `.retry_after is None`.
6. `run()` surfaces the key of a failed submit phase.
7. Cancelling an in-flight `AsyncComfy.submit()` yields the key, reads `.request_id` as `None`, and the `CancelledError` still propagates.

`tests/conftest.py` gains one additive knob, `ServerState.jobs_idempotency_keys` — every `Idempotency-Key` seen on `POST /jobs` in arrival order, mirroring the existing `model_run_idempotency_keys`. See the judgment call below for why.

## Judgment calls

- **The ticket's acceptance for test 1 asserts `exc.idempotency_key == server.state.idempotency`, which cannot work.** `ServerState.idempotency` is a `dict` of `key -> job_id` and it is only written on an *accepted* submit, so it is empty on exactly the error paths these tests exercise. I added the ordered-capture list instead (the same shape the model-run side already uses) and asserted against the key the server genuinely received, which is what the criterion was reaching for.
- **The queue-full retry budget is spent by a stepped fake clock, not by wall time.** Monkeypatching `_client_module._now` with a clock that advances 1.0s per read (budget 3.0) makes "the budget ran out after N attempts" exact. Timing it against a real 20–50 ms budget would have been a race on a loaded machine, and the assertion needs `len(sent) > 1` to mean anything.
- **The retry loop is wrapped; `_guard_ui_format` and `_materialize` are not**, per the ticket. Both run before the key is minted, so a failure there genuinely has no key to carry.
- **`run()`'s polling phase is deliberately not stamped.** Once `submit` returns, the job exists and is addressed by its id; a submit key there would be noise, and the CHANGELOG scopes the guarantee to "a failed call".
- **Line references in the ticket had drifted** (it names `client.py:161-173` and `README.md:523` from the #97 branch; on today's `main` they are `client.py:329` / `README.md:587`, and the import line is `MissingApiKey, WorkflowFormatUi, to_sdk_error`, not the `QueueFull, ...` the ticket quotes). I matched the code, not the line numbers.
- The prerequisite (#97) is merged, so this branches off `main` rather than stacking. #99 is also merged and touches `models.py`/`retry.py` only — no overlap.

## Residual

- **Asset uploads still send an `Idempotency-Key` without stamping it.** `AssetHandle` mints one per handle (`src/comfy_sdk/assets.py:69`) and passes it to `post_assets` (`assets.py:139`, `assets.py:185`) inside a bare `with translating():` — no key argument — so every exception an upload raises still reads `.idempotency_key is None`. That is out of this change's scope (the ticket scopes to `submit`), but it makes the flat sentence the ticket asked for in the docs (`None` on operations that "send no key") **untrue**, so I did not write it: the `ComfyError.idempotency_key` docstring and the README paragraph both name the asset-upload surface explicitly as the remaining key-sending-but-unrecording one. Fixing it is a one-line change per call site (`with translating(idempotency_key=self._idempotency_key):`) plus its own tests, and it deserves a decision first, because an upload key is deduplicated by content hash and its recovery story is not the same as a job's.
- **No live deployment was exercised.** Everything here runs against the in-repo stub server; the reject-not-replay semantics this PR documents are cited from the vendored `spec/openapi.yaml` and `spec/router-openapi.yaml`, not observed against Comfy Cloud. `tests/integration` needs a live target and a credential and was not run.
- The ticket's linked spike issue and its findings comment are named but not reachable from this environment, so the evidence behind the ticket was taken as given rather than re-read.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `uv run --extra dev pytest -q`: 732 passed, 4 skipped, 0 failed (full suite, under the shared per-repo suite lock); `uv run --extra dev ruff check .`: all checks passed; `uv run --extra dev ruff format --check .`: 52 files already formatted; `uv run --extra dev mypy src`: no issues in 19 source files. `tests/integration` not run (needs a live deployment + credential).
- **Deviations:** ticket test-criterion 1's `server.state.idempotency` assertion replaced with an ordered header capture (see Judgment calls); the docs sentence the ticket dictated was amended so it does not make a false claim about asset uploads (see Residual). No other criterion skipped.
