### PR TITLE
feat: name the status on an unrecognised error and keep the body that explains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,24 @@ notes for each version.
 ### Added
 
 - `ApiError.body_excerpt` — a bounded, single-line excerpt of a response body
-  that carried no error envelope, and `str(exc)` now shows it beside a bare
-  status: `HTTP 503: no healthy upstream`. A `503` answered by a load balancer
-  in front of the deployment arrives as plain text with no JSON and no
-  `X-Comfy-Request-Id`, and that text — `no healthy upstream`, `upstream connect
-  error or disconnect/reset before headers` — is the only thing that names the
-  cause. It used to be discarded with the response, so the cause was
-  unrecoverable from any log. The excerpt is whitespace-collapsed, stripped of
-  control characters and capped at 256 characters (an HTML error page is the
-  realistic case), and it is `None` whenever the body *was* a well-formed
-  envelope, where `message` already carries the cause. It is deliberately not
-  spliced into a message the server actually sent. The `invalid_response` error
-  — a success status whose body would not decode, i.e. a proxy interstitial
-  served as a `200` — carries it too, for the same reason: the message says the
-  body would not decode, and only the excerpt says what answered instead.
+  that stated no message of its own, and `str(exc)` now shows it beside the
+  bare status: `HTTP 503: no healthy upstream`. The `ComfyError` it is
+  translated to carries the same string as its message, so the cause reaches
+  the exception an integrator actually catches and logs. A `503` answered by a
+  load balancer in front of the deployment arrives as plain text with no JSON
+  and no `X-Comfy-Request-Id`, and that text — `no healthy upstream`, `upstream
+  connect error or disconnect/reset before headers` — is the only thing that
+  names the cause. It used to be discarded with the response, so the cause was
+  unrecoverable from any log. The excerpt is whitespace-collapsed, has control,
+  format (bidi override, zero-width), private-use and surrogate characters
+  replaced by spaces, and is capped at 256 characters (an HTML error page is
+  the realistic case). It is `None` whenever the response *did* state a message
+  — an envelope's `error.message`, Router's `detail` — where `message` already
+  carries the cause; a JSON object that is not an envelope (`{"message": "no
+  healthy upstream"}`) keeps its excerpt. The `invalid_response` error — a
+  success status whose body would not decode, i.e. a proxy interstitial served
+  as a `200` — carries and shows it too, for the same reason: the message says
+  the body would not decode, and only the excerpt says what answered instead.
 
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,40 @@ notes for each version.
   input. The README's "Image to image — upload an asset first" section walks
   through the flow.
 
+- `ApiError.body_excerpt` — a bounded, single-line excerpt of a response body
+  that stated no message of its own, and `str(exc)` now shows it beside the
+  bare status: `HTTP 503: no healthy upstream`. The `ComfyError` it is
+  translated to carries the same string as its message, so the cause reaches
+  the exception an integrator actually catches and logs. A `503` answered by a
+  load balancer in front of the deployment arrives as plain text with no JSON
+  and no `X-Comfy-Request-Id`, and that text — `no healthy upstream`, `upstream
+  connect error or disconnect/reset before headers` — is the only thing that
+  names the cause. It used to be discarded with the response, so the cause was
+  unrecoverable from any log. The excerpt is whitespace-collapsed, has control,
+  format (bidi override, zero-width), private-use and surrogate characters
+  replaced by spaces, and is capped at 256 characters (an HTML error page is
+  the realistic case). It is `None` whenever the response *did* state a message
+  — an envelope's `error.message`, Router's `detail` — where `message` already
+  carries the cause; a JSON object that is not an envelope (`{"message": "no
+  healthy upstream"}`) keeps its excerpt. The `invalid_response` error — a
+  success status whose body would not decode, i.e. a proxy interstitial served
+  as a `200` — carries and shows it too, for the same reason: the message says
+  the body would not decode, and only the excerpt says what answered instead.
+
+### Changed
+
+- An error response nothing in the stack recognised now carries the code
+  `http_<status>` — `http_503`, `http_500` — instead of `"error"`. It is reached
+  only after the envelope's own `code`, Router's `X-Comfy-Error-Type` bucket and
+  the status table have all declined, so a bare `401` still maps to
+  `Unauthorized` and every documented code is untouched. `"error"` was the class
+  default an exception built by hand carries, so it was indistinguishable from
+  "nobody set a code" and told a caller nothing about a response that had
+  already lost its body. Read `http_<status>` as *answered by something in front
+  of Router rather than by the service itself, so no service verdict was
+  reached; retry per your own policy* — nothing about what the SDK retries
+  changed, and such a `5xx` is still not retried automatically.
+
 ## [0.1.9] - 2026-09-01
 
 ### Added
@@ -55,26 +89,6 @@ notes for each version.
   Previously `""` fell into the mint-a-fresh-key branch — disabling the
   caller's dedup and, with the stamp above, reporting a key the caller never
   passed — and an invalid key failed at the transport after the round trip.
-
-- `ApiError.body_excerpt` — a bounded, single-line excerpt of a response body
-  that stated no message of its own, and `str(exc)` now shows it beside the
-  bare status: `HTTP 503: no healthy upstream`. The `ComfyError` it is
-  translated to carries the same string as its message, so the cause reaches
-  the exception an integrator actually catches and logs. A `503` answered by a
-  load balancer in front of the deployment arrives as plain text with no JSON
-  and no `X-Comfy-Request-Id`, and that text — `no healthy upstream`, `upstream
-  connect error or disconnect/reset before headers` — is the only thing that
-  names the cause. It used to be discarded with the response, so the cause was
-  unrecoverable from any log. The excerpt is whitespace-collapsed, has control,
-  format (bidi override, zero-width), private-use and surrogate characters
-  replaced by spaces, and is capped at 256 characters (an HTML error page is
-  the realistic case). It is `None` whenever the response *did* state a message
-  — an envelope's `error.message`, Router's `detail` — where `message` already
-  carries the cause; a JSON object that is not an envelope (`{"message": "no
-  healthy upstream"}`) keeps its excerpt. The `invalid_response` error — a
-  success status whose body would not decode, i.e. a proxy interstitial served
-  as a `200` — carries and shows it too, for the same reason: the message says
-  the body would not decode, and only the excerpt says what answered instead.
 
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the
@@ -200,18 +214,6 @@ notes for each version.
   against the URL exactly as given.
 
 ### Changed
-
-- An error response nothing in the stack recognised now carries the code
-  `http_<status>` — `http_503`, `http_500` — instead of `"error"`. It is reached
-  only after the envelope's own `code`, Router's `X-Comfy-Error-Type` bucket and
-  the status table have all declined, so a bare `401` still maps to
-  `Unauthorized` and every documented code is untouched. `"error"` was the class
-  default an exception built by hand carries, so it was indistinguishable from
-  "nobody set a code" and told a caller nothing about a response that had
-  already lost its body. Read `http_<status>` as *answered by something in front
-  of Router rather than by the service itself, so no service verdict was
-  reached; retry per your own policy* — nothing about what the SDK retries
-  changed, and such a `5xx` is still not retried automatically.
 
 - **`client.models.run` posts to Comfy Router.** It sends
   `POST {COMFY_ROUTER_BASE_URL}/v2/models/{provider}/{model}` — the route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ notes for each version.
 
 ### Added
 
+- `ApiError.body_excerpt` — a bounded, single-line excerpt of a response body
+  that carried no error envelope, and `str(exc)` now shows it beside a bare
+  status: `HTTP 503: no healthy upstream`. A `503` answered by a load balancer
+  in front of the deployment arrives as plain text with no JSON and no
+  `X-Comfy-Request-Id`, and that text — `no healthy upstream`, `upstream connect
+  error or disconnect/reset before headers` — is the only thing that names the
+  cause. It used to be discarded with the response, so the cause was
+  unrecoverable from any log. The excerpt is whitespace-collapsed, stripped of
+  control characters and capped at 256 characters (an HTML error page is the
+  realistic case), and it is `None` whenever the body *was* a well-formed
+  envelope, where `message` already carries the cause. It is deliberately not
+  spliced into a message the server actually sent. The `invalid_response` error
+  — a success status whose body would not decode, i.e. a proxy interstitial
+  served as a `200` — carries it too, for the same reason: the message says the
+  body would not decode, and only the excerpt says what answered instead.
+
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the
   typed `RouterError` buckets, a `RouterError` whose `error_type` this version
@@ -146,6 +162,18 @@ notes for each version.
   against the URL exactly as given.
 
 ### Changed
+
+- An error response nothing in the stack recognised now carries the code
+  `http_<status>` — `http_503`, `http_500` — instead of `"error"`. It is reached
+  only after the envelope's own `code`, Router's `X-Comfy-Error-Type` bucket and
+  the status table have all declined, so a bare `401` still maps to
+  `Unauthorized` and every documented code is untouched. `"error"` was the class
+  default an exception built by hand carries, so it was indistinguishable from
+  "nobody set a code" and told a caller nothing about a response that had
+  already lost its body. Read `http_<status>` as *answered by something in front
+  of Router rather than by the service itself, so no service verdict was
+  reached; retry per your own policy* — nothing about what the SDK retries
+  changed, and such a `5xx` is still not retried automatically.
 
 - **Breaking (wire): `client.models.run` now posts to Comfy Router.** It sends
   `POST {COMFY_ROUTER_BASE_URL}/v1/models/{provider}/{model}` — the route

--- a/README.md
+++ b/README.md
@@ -645,8 +645,8 @@ asset, job, event, and output helpers translate protocol errors, so catches of
   your own policy; the SDK does not retry these for you. The one line naming
   the cause (`no healthy upstream`, `upstream connect error or disconnect/reset
   before headers`) is kept on the protocol-level exception as
-  `comfy_low.errors.ApiError.body_excerpt`, and appears in that exception's
-  `str()` — `HTTP 503: no healthy upstream`.
+  `comfy_low.errors.ApiError.body_excerpt`, and is what `str()` of the error
+  you catch reads — `HTTP 503: no healthy upstream` — at both layers.
 
 ```python
 from comfy_sdk import JobFailed, QueueFull, Unauthorized

--- a/README.md
+++ b/README.md
@@ -638,6 +638,15 @@ asset, job, event, and output helpers translate protocol errors, so catches of
   deployment warm-up), then raises the translated error if backpressure remains.
 - `JobFailed` — a job reached a non-`succeeded` terminal state; `.error`
   carries node-level detail when the platform provided one.
+- A plain `ComfyError` whose `.code` reads `http_<status>` (`http_503`,
+  `http_500`) — the response was answered by something in front of Router
+  rather than by the service itself, so no service verdict was reached: no
+  error envelope, no error bucket, usually no `X-Comfy-Request-Id`. Retry per
+  your own policy; the SDK does not retry these for you. The one line naming
+  the cause (`no healthy upstream`, `upstream connect error or disconnect/reset
+  before headers`) is kept on the protocol-level exception as
+  `comfy_low.errors.ApiError.body_excerpt`, and appears in that exception's
+  `str()` — `HTTP 503: no healthy upstream`.
 
 ```python
 from comfy_sdk import JobFailed, QueueFull, Unauthorized

--- a/src/comfy_low/errors.py
+++ b/src/comfy_low/errors.py
@@ -38,6 +38,36 @@ def clean_request_id(raw: Any) -> str | None:
     return match.group(0) if match else None
 
 
+#: Longest body excerpt kept on an exception. Long enough for the one-line
+#: reason an intermediary states (``no healthy upstream``, ``upstream connect
+#: error or disconnect/reset before headers``), short enough that an HTML error
+#: page cannot flood the log line that prints it.
+_BODY_EXCERPT_LIMIT = 256
+
+#: Control characters dropped from a body excerpt. The excerpt is
+#: server-controlled text headed for a traceback or a log line, so it is reduced
+#: to something safe to *display* for the same reason ``clean_request_id``
+#: bounds the id: an escape sequence in an error page must not repaint the
+#: terminal reading it. The C1 range goes too — it is what a stray byte of
+#: Latin-1-decoded binary lands in.
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def clean_body_excerpt(raw: Any, *, limit: int = _BODY_EXCERPT_LIMIT) -> str | None:
+    """``raw`` reduced to a bounded single-line excerpt, or ``None``.
+
+    Whitespace of every kind collapses to single spaces before the bound is
+    applied, so an indented HTML error page spends its budget on words rather
+    than on the margin, and the result is one line wherever it is printed.
+    Truncation is deliberately silent — no ellipsis — so the value stays exactly
+    what the server said, up to ``limit`` characters of it.
+    """
+    if not isinstance(raw, str):
+        return None
+    collapsed = _CONTROL_RE.sub("", " ".join(raw.split()))
+    return collapsed[:limit] or None
+
+
 class ApiError(Exception):
     """Base for every error carried by the API's error envelope."""
 
@@ -52,6 +82,7 @@ class ApiError(Exception):
         details: dict[str, Any] | None = None,
         retry_after: int | None = None,
         request_id: str | None = None,
+        body_excerpt: str | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
@@ -66,6 +97,29 @@ class ApiError(Exception):
         #: because it is the id a user quotes in a support request and it is
         #: unreachable once the response object is gone.
         self.request_id = request_id
+        #: A bounded, single-line excerpt of a response body that carried no
+        #: error envelope, or ``None``. It is the only place such a response
+        #: states its cause: something in front of the API — a load balancer, a
+        #: proxy — answers with plain text (``no healthy upstream``, ``upstream
+        #: connect error or disconnect/reset before headers``) and no JSON, and
+        #: that text used to be discarded with the response, leaving the cause
+        #: unrecoverable from any log. ``None`` whenever the body *was* a
+        #: well-formed envelope, where ``message`` already carries the cause.
+        self.body_excerpt = body_excerpt
+
+    def __str__(self) -> str:
+        """``message``, plus the body excerpt when the message is a bare status.
+
+        A response with no envelope has no message to carry, so ``message`` is
+        the synthetic ``HTTP <status>`` — which names no cause. Appending the
+        excerpt there is what puts the cause into the one string a caller prints
+        and a logger formats: ``HTTP 503: no healthy upstream``. When the
+        response *did* state a message, that message is the cause and the
+        excerpt is not spliced into it; it stays readable on ``.body_excerpt``.
+        """
+        if self.body_excerpt and self.message == f"HTTP {self.http_status}":
+            return f"{self.message}: {self.body_excerpt}"
+        return self.message
 
 
 class InvalidWorkflow(ApiError):
@@ -151,6 +205,7 @@ def error_from_envelope(
     retry_after: int | None = None,
     request_id: str | None = None,
     error_type: str | None = None,
+    body_excerpt: str | None = None,
 ) -> ApiError:
     """Build the typed exception for an error response.
 
@@ -158,21 +213,28 @@ def error_from_envelope(
     well-formed envelope (so a bare ``401`` with no JSON still maps to
     ``Unauthorized``).
 
+    ``body_excerpt`` is the caller's already-reduced excerpt of a non-envelope
+    body (:func:`clean_body_excerpt`), kept on the exception because such a
+    response states its cause nowhere else. It is the caller's to pass rather
+    than this function's to read: only the caller holds the response, and only
+    it can tell an unread streaming body from an empty one.
+
     Not every route answers in the envelope shape. ``POST {router}/v2/models/{provider}/{model}``
     is fronted by Router, whose error body is ``{detail, error_type}`` and which
     repeats the same coarse bucket on the ``X-Comfy-Error-Type`` header
     (``spec/router-openapi.yaml``). Reading only ``error["code"]`` would collapse
     every one of those to the status-derived default — for a ``504`` that
-    default is the meaningless ``"error"``, and ``comfy_sdk.retry`` keys its
-    default-on collect rule on the bucket, so the rule would be a silent no-op
-    against every real Router ``504``. ``error_type`` (the header, passed by the
+    default names only the status (``"http_504"``), and ``comfy_sdk.retry`` keys
+    its default-on collect rule on the bucket, so the rule would be a silent
+    no-op against every real Router ``504``. ``error_type`` (the header, passed by the
     caller) and the body's own top-level ``error_type`` are read to prevent that.
 
     The precedence is: the envelope's ``code`` always wins; then, when the
     response identifies itself as Router's — the ``X-Comfy-Error-Type`` header
     or a top-level body ``error_type`` is present — that bucket wins for EVERY
     status; only then does :data:`_CODE_BY_STATUS` fill in, for the bare and
-    proxy-shaped responses it was built for.
+    proxy-shaped responses it was built for; and a status that table does not
+    name falls back to ``http_<status>`` (see below).
 
     The bucket outranking the status table is the load-bearing choice, learned
     three times on live traffic: the table turned Router's ``409`` errors into
@@ -198,7 +260,18 @@ def error_from_envelope(
     if code is None:
         code = _CODE_BY_STATUS.get(http_status)
     if code is None:
-        code = "error"
+        # Nothing identified this response: no envelope ``code``, no Router
+        # bucket, and a status :data:`_CODE_BY_STATUS` does not name. ``"error"``
+        # was the answer here, and it was indistinguishable from the class
+        # default an exception built by hand carries — so it told a caller
+        # nothing at all, on the one class of failure where the SDK has nothing
+        # else to say. The status is the single fact such a response does carry,
+        # so it becomes the code. The shape is deliberately prefixed rather than
+        # bare: ``http_503`` reads as "no service verdict was reached — something
+        # in front of the API answered", which is exactly what it means, and it
+        # cannot collide with a wire ``code`` or a Router bucket, none of which
+        # are spelled that way.
+        code = f"http_{http_status}"
     if not message:
         # Router names its human-readable string `detail`, not `error.message`.
         message = _clean((body or {}).get("detail") if isinstance(body, dict) else None)
@@ -213,6 +286,7 @@ def error_from_envelope(
         details=details if isinstance(details, dict) else None,
         retry_after=retry_after,
         request_id=request_id,
+        body_excerpt=body_excerpt,
     )
 
 

--- a/src/comfy_low/errors.py
+++ b/src/comfy_low/errors.py
@@ -10,6 +10,7 @@ stable, typed error surface.
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Any
 
 #: The leading run of characters a request id may consist of, bounded in the
@@ -44,27 +45,49 @@ def clean_request_id(raw: Any) -> str | None:
 #: page cannot flood the log line that prints it.
 _BODY_EXCERPT_LIMIT = 256
 
-#: Control characters dropped from a body excerpt. The excerpt is
-#: server-controlled text headed for a traceback or a log line, so it is reduced
-#: to something safe to *display* for the same reason ``clean_request_id``
-#: bounds the id: an escape sequence in an error page must not repaint the
-#: terminal reading it. The C1 range goes too — it is what a stray byte of
-#: Latin-1-decoded binary lands in.
-_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+#: Unicode general categories replaced by a space in a body excerpt. The
+#: excerpt is server-controlled text headed for a traceback or a log line, so
+#: it is reduced to something safe to *display* for the same reason
+#: ``clean_request_id`` bounds the id: an escape sequence in an error page must
+#: not repaint the terminal reading it. ``Cc`` is the C0/C1 control range (the
+#: C1 half is where a stray byte of Latin-1-decoded binary lands); ``Cf`` is the
+#: format characters — bidi overrides that reverse how a log line reads,
+#: zero-width joiners and spaces that hide a break, the BOM; ``Co`` and ``Cs``
+#: are private-use and lone surrogates, which no error page has a reason to
+#: contain and no terminal has a glyph for.
+_UNPRINTABLE_CATEGORIES = frozenset({"Cc", "Cf", "Co", "Cs"})
+
+#: How much of a body is walked to produce an excerpt, as a multiple of the
+#: excerpt limit. Collapsing whitespace and mapping characters is linear in the
+#: input, and an error page can be megabytes; the reduction has to cost the
+#: same for a 2 KiB body and a 20 MiB one.
+_BODY_EXCERPT_WINDOW = 8
 
 
 def clean_body_excerpt(raw: Any, *, limit: int = _BODY_EXCERPT_LIMIT) -> str | None:
     """``raw`` reduced to a bounded single-line excerpt, or ``None``.
 
-    Whitespace of every kind collapses to single spaces before the bound is
-    applied, so an indented HTML error page spends its budget on words rather
-    than on the margin, and the result is one line wherever it is printed.
-    Truncation is deliberately silent — no ellipsis — so the value stays exactly
-    what the server said, up to ``limit`` characters of it.
+    Unprintable characters become spaces rather than vanishing, so ``no
+    healthy\\x00upstream`` reads ``no healthy upstream`` and not ``no
+    healthyupstream``. Whitespace of every kind then collapses to single spaces
+    before the bound is applied, so an indented HTML error page spends its
+    budget on words rather than on the margin, and the result is one line
+    wherever it is printed. Truncation is deliberately silent — no ellipsis — so
+    the value stays exactly what the server said, up to ``limit`` characters of
+    it.
+
+    Only a bounded head of ``raw`` is examined (leading whitespace aside, which
+    is stripped first so an indented page still yields its words): a few
+    kilobytes is enough to fill a 256-character excerpt of any real error page,
+    and it keeps the cost of describing a huge body independent of its size.
     """
     if not isinstance(raw, str):
         return None
-    collapsed = _CONTROL_RE.sub("", " ".join(raw.split()))
+    head = raw.lstrip()[: limit * _BODY_EXCERPT_WINDOW]
+    printable = "".join(
+        " " if unicodedata.category(ch) in _UNPRINTABLE_CATEGORIES else ch for ch in head
+    )
+    collapsed = " ".join(printable.split())
     return collapsed[:limit] or None
 
 
@@ -97,27 +120,31 @@ class ApiError(Exception):
         #: because it is the id a user quotes in a support request and it is
         #: unreachable once the response object is gone.
         self.request_id = request_id
-        #: A bounded, single-line excerpt of a response body that carried no
-        #: error envelope, or ``None``. It is the only place such a response
+        #: A bounded, single-line excerpt of a response body that stated no
+        #: message of its own, or ``None``. It is the only place such a response
         #: states its cause: something in front of the API — a load balancer, a
         #: proxy — answers with plain text (``no healthy upstream``, ``upstream
         #: connect error or disconnect/reset before headers``) and no JSON, and
         #: that text used to be discarded with the response, leaving the cause
-        #: unrecoverable from any log. ``None`` whenever the body *was* a
-        #: well-formed envelope, where ``message`` already carries the cause.
+        #: unrecoverable from any log. ``None`` whenever the response *did*
+        #: state a message — an envelope's ``error.message``, Router's
+        #: ``detail`` — because there ``message`` already carries the cause;
+        #: :func:`error_from_envelope` enforces that, so a set excerpt always
+        #: means ``message`` is one this SDK synthesised.
         self.body_excerpt = body_excerpt
 
     def __str__(self) -> str:
-        """``message``, plus the body excerpt when the message is a bare status.
+        """``message``, plus the body excerpt whenever there is one.
 
-        A response with no envelope has no message to carry, so ``message`` is
-        the synthetic ``HTTP <status>`` — which names no cause. Appending the
-        excerpt there is what puts the cause into the one string a caller prints
-        and a logger formats: ``HTTP 503: no healthy upstream``. When the
-        response *did* state a message, that message is the cause and the
-        excerpt is not spliced into it; it stays readable on ``.body_excerpt``.
+        An excerpt is only ever kept beside a message this SDK made up — the
+        ``HTTP <status>`` of a response with no envelope, the "could not decode"
+        of a success whose body was not JSON — and such a message names no
+        cause. Appending the excerpt is what puts the cause into the one string
+        a caller prints and a logger formats: ``HTTP 503: no healthy upstream``.
+        A message the server actually sent never has an excerpt beside it (see
+        :attr:`body_excerpt`), so it is returned unchanged.
         """
-        if self.body_excerpt and self.message == f"HTTP {self.http_status}":
+        if self.body_excerpt:
             return f"{self.message}: {self.body_excerpt}"
         return self.message
 
@@ -213,11 +240,17 @@ def error_from_envelope(
     well-formed envelope (so a bare ``401`` with no JSON still maps to
     ``Unauthorized``).
 
-    ``body_excerpt`` is the caller's already-reduced excerpt of a non-envelope
-    body (:func:`clean_body_excerpt`), kept on the exception because such a
-    response states its cause nowhere else. It is the caller's to pass rather
-    than this function's to read: only the caller holds the response, and only
-    it can tell an unread streaming body from an empty one.
+    ``body_excerpt`` is the caller's already-reduced excerpt of the body
+    (:func:`clean_body_excerpt`). It is kept on the exception only when no
+    message could be read from the body — a response with no envelope states
+    its cause nowhere else, while one that carried ``error.message`` or Router's
+    ``detail`` has already said everything it is going to say, and a second copy
+    of the same text helps nobody. The gate lives here rather than at the raise
+    site because this is the function that knows whether a message was found:
+    ``{"message": "no healthy upstream"}`` is a JSON object and still not an
+    envelope. The text itself is the caller's to pass rather than this
+    function's to read: only the caller holds the response, and only it can
+    tell an unread streaming body from an empty one.
 
     Not every route answers in the envelope shape. ``POST {router}/v2/models/{provider}/{model}``
     is fronted by Router, whose error body is ``{detail, error_type}`` and which
@@ -250,7 +283,11 @@ def error_from_envelope(
     """
     err = (body or {}).get("error") if isinstance(body, dict) else None
     code = (err or {}).get("code") if isinstance(err, dict) else None
-    message = (err or {}).get("message") if isinstance(err, dict) else None
+    # Through `_clean` like every other string read off the wire: `message` ends
+    # up as `str(exc)`, and a non-string here (a list, a number) would make that
+    # raise `TypeError: __str__ returned non-string` at the one moment — inside
+    # a logger or a traceback — where an exception must not fail.
+    message = _clean((err or {}).get("message") if isinstance(err, dict) else None)
     details = (err or {}).get("details") if isinstance(err, dict) else None
 
     if code is None:
@@ -275,7 +312,11 @@ def error_from_envelope(
     if not message:
         # Router names its human-readable string `detail`, not `error.message`.
         message = _clean((body or {}).get("detail") if isinstance(body, dict) else None)
-    if not message:
+    if message:
+        # The response stated its cause; the excerpt would be a second copy of
+        # it (or of the envelope around it). See the docstring.
+        body_excerpt = None
+    else:
         message = f"HTTP {http_status}"
 
     cls = _BY_CODE.get(code, ApiError)

--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -375,24 +375,26 @@ class _Prepared:
             # Passing it here is what keeps the bucket alive across the layer
             # boundary; see `error_from_envelope`.
             error_type=resp.headers.get("X-Comfy-Error-Type"),
-            # Only for a body that is not an envelope: there the response has
-            # already said everything it is going to say in its `message`, and
-            # a second copy of the same text helps nobody. Everywhere else this
-            # is the only statement of the cause the response made.
-            body_excerpt=None if isinstance(body, dict) else _body_excerpt(resp),
+            # Passed for every error response; `error_from_envelope` keeps it
+            # only when it found no message in the body, because it is the one
+            # place that knows — `{"message": "no healthy upstream"}` is a JSON
+            # object and still not an envelope. For such a response the text is
+            # the only statement of the cause it made.
+            body_excerpt=_body_excerpt(resp),
         )
 
 
 def _body_excerpt(resp: httpx.Response) -> str | None:
     """A bounded, single-line excerpt of ``resp``'s body text, or ``None``.
 
-    Read off the two responses whose body was not the JSON this client expected,
-    where the text served instead is the sole statement of what answered: a load
-    balancer in front of the deployment answering a ``503`` with ``no healthy
-    upstream`` or ``upstream connect error or disconnect/reset before headers``,
-    as plain text with no JSON and no ``X-Comfy-Request-Id``; and a proxy
-    interstitial served with a success status. Both used to discard that text
-    with the response.
+    Read off every error response and off a success whose body would not
+    decode, and kept (by ``error_from_envelope``) only where the body stated no
+    message of its own — there the text served is the sole statement of what
+    answered: a load balancer in front of the deployment answering a ``503``
+    with ``no healthy upstream`` or ``upstream connect error or disconnect/reset
+    before headers``, as plain text with no JSON and no ``X-Comfy-Request-Id``;
+    a proxy interstitial served with a success status. Both used to discard
+    that text with the response.
 
     Never raises, for the same reason the ``resp.json()`` above is guarded:
     ``resp.text`` decodes the *buffered* body and raises ``ResponseNotRead`` on a

--- a/src/comfy_low/transport.py
+++ b/src/comfy_low/transport.py
@@ -44,7 +44,7 @@ from urllib.parse import parse_qs, quote, urlsplit, urlunsplit
 import httpx
 
 from . import _multipart
-from .errors import ApiError, clean_request_id, error_from_envelope
+from .errors import ApiError, clean_body_excerpt, clean_request_id, error_from_envelope
 from .models import Asset, Job, JobWorkflowResponse
 from .sse import RawEvent, SSEDecoder
 
@@ -355,6 +355,10 @@ class _Prepared:
                     code="invalid_response",
                     http_status=resp.status_code,
                     request_id=_request_id(resp),
+                    # Whatever was served instead is the only description of
+                    # what answered — the interstitial's own text names the
+                    # proxy, and it is discarded with the response otherwise.
+                    body_excerpt=_body_excerpt(resp),
                 ) from exc
         body: dict[str, Any] | None
         try:
@@ -371,7 +375,34 @@ class _Prepared:
             # Passing it here is what keeps the bucket alive across the layer
             # boundary; see `error_from_envelope`.
             error_type=resp.headers.get("X-Comfy-Error-Type"),
+            # Only for a body that is not an envelope: there the response has
+            # already said everything it is going to say in its `message`, and
+            # a second copy of the same text helps nobody. Everywhere else this
+            # is the only statement of the cause the response made.
+            body_excerpt=None if isinstance(body, dict) else _body_excerpt(resp),
         )
+
+
+def _body_excerpt(resp: httpx.Response) -> str | None:
+    """A bounded, single-line excerpt of ``resp``'s body text, or ``None``.
+
+    Read off the two responses whose body was not the JSON this client expected,
+    where the text served instead is the sole statement of what answered: a load
+    balancer in front of the deployment answering a ``503`` with ``no healthy
+    upstream`` or ``upstream connect error or disconnect/reset before headers``,
+    as plain text with no JSON and no ``X-Comfy-Request-Id``; and a proxy
+    interstitial served with a success status. Both used to discard that text
+    with the response.
+
+    Never raises, for the same reason the ``resp.json()`` above is guarded:
+    ``resp.text`` decodes the *buffered* body and raises ``ResponseNotRead`` on a
+    streaming response nothing has read yet, and a failure while composing an
+    error message must not replace the error it was describing.
+    """
+    try:
+        return clean_body_excerpt(resp.text)
+    except Exception:
+        return None
 
 
 def parse_expiry(url: str) -> datetime | None:

--- a/src/comfy_sdk/exceptions.py
+++ b/src/comfy_sdk/exceptions.py
@@ -191,9 +191,14 @@ def _router_only_class(code: str) -> type[Any] | None:
 
 def to_sdk_error(exc: ApiError) -> ComfyError:
     """Translate a protocol ``ApiError`` into the idiomatic SDK exception."""
+    # `str(exc)`, not `exc.message`: they differ only when the protocol error
+    # carries a body excerpt — a response that stated no message of its own —
+    # and then `str(exc)` is the one that names the cause (`HTTP 503: no healthy
+    # upstream`). Callers read the SDK exception, never the protocol one, so the
+    # cause has to cross this boundary or it reaches no log.
     if exc.code == "queue_full":
         return QueueFull(
-            exc.message,
+            str(exc),
             retry_after=exc.retry_after or 0,
             code=exc.code,
             http_status=exc.http_status,
@@ -203,7 +208,7 @@ def to_sdk_error(exc: ApiError) -> ComfyError:
     router_cls = _router_only_class(exc.code)
     if router_cls is not None:
         return router_cls(
-            exc.message,
+            str(exc),
             error_type=exc.code,
             http_status=exc.http_status,
             request_id=exc.request_id,
@@ -211,7 +216,7 @@ def to_sdk_error(exc: ApiError) -> ComfyError:
         )
     cls = _BY_CODE.get(exc.code, ComfyError)
     return cls(
-        exc.message,
+        str(exc),
         code=exc.code,
         http_status=exc.http_status,
         details=exc.details,

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -6,10 +6,19 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
-from comfy_low.errors import ApiError, QueueFull, error_from_envelope
-from comfy_sdk.exceptions import NotFound, to_sdk_error
+import comfy_low.transport as low_transport
+from comfy_low.errors import (
+    ApiError,
+    QueueFull,
+    Unauthorized,
+    clean_body_excerpt,
+    error_from_envelope,
+)
+from comfy_sdk.exceptions import ComfyError, NotFound, to_sdk_error
+from comfy_sdk.retry import RetryPolicy, error_bucket_of, is_collectable
 
 
 @pytest.mark.parametrize("code", ["not_found", "job_not_found", "asset_not_found"])
@@ -158,3 +167,161 @@ def test_a_bucket_both_surfaces_spell_keeps_its_v2_class(code: str) -> None:
 
     err = to_sdk_error(ApiError("no", code=code, http_status=403))
     assert type(err) is getattr(sdk, "".join(p.title() for p in code.split("_")))
+
+
+# --- a response nothing in the stack recognised ---
+#
+# A 5xx answered by a load balancer in front of the deployment carries no
+# envelope, no Router bucket and no `X-Comfy-Request-Id` -- just a status and a
+# line of plain text naming the cause. Both halves of that used to be lost: the
+# code degraded to `"error"`, which is the class default an exception built by
+# hand carries and so says nothing about the response, and the text was
+# discarded with the response, leaving nothing in any log to diagnose from.
+
+
+def test_an_unrecognised_status_becomes_a_code_naming_that_status() -> None:
+    err = error_from_envelope(503, None)
+    assert err.code == "http_503"
+    assert type(err) is ApiError
+
+
+def test_a_status_the_table_names_is_untouched_by_that_fallback() -> None:
+    # The fallback is reached only after `_CODE_BY_STATUS`, so a bare 401 with
+    # no body at all still maps to the typed Unauthorized a caller catches.
+    err = error_from_envelope(401, None)
+    assert isinstance(err, Unauthorized)
+    assert err.code == "unauthorized"
+
+
+def test_an_envelope_code_still_wins_over_the_status_fallback() -> None:
+    err = error_from_envelope(503, {"error": {"code": "queue_full", "message": "full"}})
+    assert isinstance(err, QueueFull)
+    assert err.code == "queue_full"
+    assert err.body_excerpt is None
+
+
+def test_the_body_excerpt_is_kept_and_shown_beside_a_bare_status() -> None:
+    err = error_from_envelope(503, None, body_excerpt=clean_body_excerpt("no healthy upstream"))
+    assert err.body_excerpt == "no healthy upstream"
+    # The one string a caller prints, and a logger formats, has to carry the
+    # cause -- reading `.body_excerpt` is the deliberate second step, not the
+    # only one.
+    assert str(err) == "HTTP 503: no healthy upstream"
+
+
+def test_a_message_the_server_actually_sent_is_not_joined_to_the_excerpt() -> None:
+    # The excerpt exists because a non-envelope response states its cause
+    # nowhere else. Where the response did state one, splicing a second copy of
+    # the body into it would be noise; the excerpt stays readable as data.
+    err = error_from_envelope(
+        503, {"detail": "router is draining"}, body_excerpt="router is draining"
+    )
+    assert str(err) == "router is draining"
+    assert err.body_excerpt == "router is draining"
+
+
+def test_an_excerpt_is_collapsed_to_one_line_and_bounded() -> None:
+    # An HTML error page is the realistic non-envelope body, and it arrives
+    # indented across many lines. Collapsing before bounding spends the budget
+    # on words rather than on the margin.
+    excerpt = clean_body_excerpt("<html>\n  <body>\t503 Service Unavailable</body>\n</html>")
+    assert excerpt == "<html> <body> 503 Service Unavailable</body> </html>"
+
+
+def test_a_two_kilobyte_body_is_truncated() -> None:
+    excerpt = clean_body_excerpt("x" * 2048)
+    assert excerpt is not None
+    assert len(excerpt) == 256
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\n\t ", None, b"bytes", 503])
+def test_a_body_that_says_nothing_leaves_no_excerpt(raw: object) -> None:
+    assert clean_body_excerpt(raw) is None
+
+
+def test_a_terminal_escape_in_the_body_is_not_written_into_a_log() -> None:
+    # The excerpt is server-controlled text headed for a traceback, so it is
+    # reduced to something safe to display -- the same reason the request id is.
+    assert clean_body_excerpt("no healthy \x1b[31mupstream\x00") == "no healthy [31mupstream"
+
+
+# --- what the transport actually passes at the raise site ---
+
+
+def _raised_by_transport(resp: httpx.Response) -> ApiError:
+    """The exception ``parse_or_raise`` builds for ``resp``.
+
+    Driven through the real raise site rather than through
+    ``error_from_envelope`` directly: what a caller sees depends on what the
+    transport chooses to pass, and that choice is the half a unit test of the
+    builder cannot reach.
+    """
+    prepared = low_transport._Prepared("http://example.invalid", None)
+    with pytest.raises(ApiError) as caught:
+        prepared.parse_or_raise(resp, (200,))
+    return caught.value
+
+
+def test_the_transport_keeps_the_text_of_a_load_balancers_503() -> None:
+    err = _raised_by_transport(httpx.Response(503, text="no healthy upstream"))
+    assert err.code == "http_503"
+    assert err.body_excerpt == "no healthy upstream"
+    assert str(err) == "HTTP 503: no healthy upstream"
+
+
+def test_the_transport_keeps_no_excerpt_when_the_body_was_an_envelope() -> None:
+    err = _raised_by_transport(
+        httpx.Response(429, json={"error": {"code": "queue_full", "message": "full"}})
+    )
+    assert err.code == "queue_full"
+    assert err.body_excerpt is None
+
+
+def test_a_json_body_that_is_not_an_object_still_yields_an_excerpt() -> None:
+    # `resp.json()` succeeds and returns a list; nothing in it is an envelope,
+    # so the text is still the only statement of the cause.
+    err = _raised_by_transport(httpx.Response(500, json=["upstream refused"]))
+    assert err.code == "http_500"
+    assert err.body_excerpt == '["upstream refused"]'
+
+
+def test_an_unread_streaming_body_degrades_instead_of_raising() -> None:
+    # `resp.text` raises ResponseNotRead on a streaming response nothing has
+    # read yet -- the same case `resp.json()` degrades on. A failure while
+    # composing an error message must not replace the error it describes.
+    resp = httpx.Response(503, stream=httpx.ByteStream(b"no healthy upstream"))
+    err = _raised_by_transport(resp)
+    assert err.code == "http_503"
+    assert err.body_excerpt is None
+
+
+# --- the code survives the layer boundary ---
+
+
+def test_the_status_code_reaches_the_sdk_surface_unchanged() -> None:
+    # `to_sdk_error` re-types a preserved Router bucket; `http_<status>` is not
+    # one, and must arrive intact rather than being re-typed or flattened. A
+    # caller (and the e2e harnesses) read the `http_` prefix as "no service
+    # verdict was reached".
+    err = to_sdk_error(error_from_envelope(503, None, body_excerpt="no healthy upstream"))
+    assert type(err) is ComfyError
+    assert err.code == "http_503"
+    assert err.http_status == 503
+
+
+def test_an_unrecognised_status_is_still_not_retried_on_its_own() -> None:
+    # The default policy retries a completed 5xx only where the contract says
+    # the Idempotency-Key survives it. `http_503` names no such contract, so it
+    # stays exactly as unretryable as the `"error"` it replaces.
+    exc = error_from_envelope(503, None)
+    assert error_bucket_of(exc) == "http_503"
+    assert is_collectable(exc) is False
+    assert RetryPolicy().should_retry(exc) is False
+
+
+def test_an_undecodable_success_body_keeps_what_was_served_instead() -> None:
+    # The sibling raise site: a proxy interstitial served as a 200. The message
+    # says the body would not decode; only the excerpt says what answered.
+    err = _raised_by_transport(httpx.Response(200, text="<html>proxy: gateway timeout</html>"))
+    assert err.code == "invalid_response"
+    assert err.body_excerpt == "<html>proxy: gateway timeout</html>"

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -18,6 +18,7 @@ from comfy_low.errors import (
     error_from_envelope,
 )
 from comfy_sdk.exceptions import ComfyError, NotFound, to_sdk_error
+from comfy_sdk.exceptions import Unauthorized as SdkUnauthorized
 from comfy_sdk.retry import RetryPolicy, error_bucket_of, is_collectable
 
 
@@ -210,14 +211,25 @@ def test_the_body_excerpt_is_kept_and_shown_beside_a_bare_status() -> None:
 
 
 def test_a_message_the_server_actually_sent_is_not_joined_to_the_excerpt() -> None:
-    # The excerpt exists because a non-envelope response states its cause
-    # nowhere else. Where the response did state one, splicing a second copy of
-    # the body into it would be noise; the excerpt stays readable as data.
+    # The excerpt exists because a response with no message states its cause
+    # nowhere else. Where the response did state one, a second copy of the body
+    # would be noise -- so the excerpt is dropped, not merely hidden, and
+    # `.body_excerpt` being set always means the message is a synthetic one.
     err = error_from_envelope(
-        503, {"detail": "router is draining"}, body_excerpt="router is draining"
+        503, {"detail": "router is draining"}, body_excerpt='{"detail": "router is draining"}'
     )
     assert str(err) == "router is draining"
-    assert err.body_excerpt == "router is draining"
+    assert err.body_excerpt is None
+
+
+def test_an_envelope_naming_a_code_but_no_message_keeps_the_excerpt() -> None:
+    # The gate is "did the body state a message", not "was the body JSON": a
+    # code alone leaves the message synthetic, and the excerpt is then the only
+    # text the response contributed.
+    body = {"error": {"code": "queue_full"}}
+    err = error_from_envelope(429, body, body_excerpt='{"error": {"code": "queue_full"}}')
+    assert isinstance(err, QueueFull)
+    assert str(err) == 'HTTP 429: {"error": {"code": "queue_full"}}'
 
 
 def test_an_excerpt_is_collapsed_to_one_line_and_bounded() -> None:
@@ -243,6 +255,27 @@ def test_a_terminal_escape_in_the_body_is_not_written_into_a_log() -> None:
     # The excerpt is server-controlled text headed for a traceback, so it is
     # reduced to something safe to display -- the same reason the request id is.
     assert clean_body_excerpt("no healthy \x1b[31mupstream\x00") == "no healthy [31mupstream"
+
+
+def test_a_control_character_between_words_leaves_a_space_not_a_splice() -> None:
+    # Deleting the byte would glue the words it separated into one that was
+    # never sent; a space keeps the excerpt readable as what the server said.
+    assert clean_body_excerpt("no healthy\x00upstream") == "no healthy upstream"
+
+
+def test_bidi_overrides_and_zero_width_characters_are_removed_too() -> None:
+    # A right-to-left override reverses how the rest of a log line reads, and a
+    # zero-width space hides a break; neither is a control character in the C0/C1
+    # sense, so the reduction is by Unicode category rather than by code point.
+    raw = "\ufeffno\u202ehealthy\u200bupstream\U000f0000"
+    assert clean_body_excerpt(raw) == "no healthy upstream"
+
+
+def test_leading_whitespace_beyond_the_examined_window_still_yields_the_words() -> None:
+    # Only a bounded head of the body is examined, so the work does not scale
+    # with a multi-megabyte error page; leading whitespace is stripped before
+    # the window is taken so an indented page still spends it on words.
+    assert clean_body_excerpt("\n" * 10_000 + "no healthy upstream") == "no healthy upstream"
 
 
 # --- what the transport actually passes at the raise site ---
@@ -285,6 +318,29 @@ def test_a_json_body_that_is_not_an_object_still_yields_an_excerpt() -> None:
     assert err.body_excerpt == '["upstream refused"]'
 
 
+def test_a_json_object_that_is_not_an_envelope_still_yields_an_excerpt() -> None:
+    # An intermediary that answers in JSON but not in the envelope shape --
+    # `{"message": ...}` with no `error` and no `detail` -- is a dict, and was
+    # treated as an envelope on that basis alone, losing the one line that named
+    # the cause. The gate is whether a message was read, not whether the body
+    # parsed as an object.
+    err = _raised_by_transport(httpx.Response(503, text='{"message": "no healthy upstream"}'))
+    assert err.code == "http_503"
+    assert err.body_excerpt == '{"message": "no healthy upstream"}'
+    assert str(err) == 'HTTP 503: {"message": "no healthy upstream"}'
+
+
+def test_a_non_string_envelope_message_cannot_break_str() -> None:
+    # `str(exc)` is what a logger calls; a list where the envelope promised a
+    # string must degrade to the synthetic message, not raise `TypeError:
+    # __str__ returned non-string` from inside the log call.
+    body = '{"error": {"code": "boom", "message": ["not", "a", "string"]}}'
+    err = _raised_by_transport(httpx.Response(500, text=body))
+    assert err.code == "boom"
+    assert err.message == "HTTP 500"
+    assert str(err) == f"HTTP 500: {body}"
+
+
 def test_an_unread_streaming_body_degrades_instead_of_raising() -> None:
     # `resp.text` raises ResponseNotRead on a streaming response nothing has
     # read yet -- the same case `resp.json()` degrades on. A failure while
@@ -307,6 +363,17 @@ def test_the_status_code_reaches_the_sdk_surface_unchanged() -> None:
     assert type(err) is ComfyError
     assert err.code == "http_503"
     assert err.http_status == 503
+    # The excerpt has to cross the layer boundary too: an integrator only ever
+    # holds the SDK exception, and `str(err)` is what their logger formats.
+    assert str(err) == "HTTP 503: no healthy upstream"
+
+
+def test_the_excerpt_reaches_a_typed_sdk_error_as_well() -> None:
+    # Not just the plain fallback: a bare 401 with a text body maps to the typed
+    # Unauthorized, and its message carries the text the same way.
+    err = to_sdk_error(error_from_envelope(401, None, body_excerpt="token revoked"))
+    assert isinstance(err, SdkUnauthorized)
+    assert str(err) == "HTTP 401: token revoked"
 
 
 def test_an_unrecognised_status_is_still_not_retried_on_its_own() -> None:
@@ -325,3 +392,6 @@ def test_an_undecodable_success_body_keeps_what_was_served_instead() -> None:
     err = _raised_by_transport(httpx.Response(200, text="<html>proxy: gateway timeout</html>"))
     assert err.code == "invalid_response"
     assert err.body_excerpt == "<html>proxy: gateway timeout</html>"
+    assert str(err) == (
+        "Could not decode the 200 response body as JSON: <html>proxy: gateway timeout</html>"
+    )


### PR DESCRIPTION
## ELI-5

When something in front of the deployment answers instead of the service — a load balancer with no healthy backend — you got `ApiError(code="error", message="HTTP 503")`. `"error"` is the class default any hand-built exception carries, so it told you nothing, and the one line that *did* name the cause (`no healthy upstream`) was thrown away with the response. Now you get `code="http_503"` and `HTTP 503: no healthy upstream`.

## What changed

**`code` for an unrecognised response is now `http_<status>` instead of `"error"`.** This is the last fallback in `error_from_envelope`, reached only after the envelope's own `error.code`, Router's `X-Comfy-Error-Type` bucket, *and* `_CODE_BY_STATUS` have all declined. `_CODE_BY_STATUS` is untouched — a bare `401` with no body still maps to `Unauthorized`, and every documented code is unaffected. `"error"` was indistinguishable from "nobody set a code", on the one class of failure where the SDK has nothing else to say; the status is the single fact such a response does carry. The `http_` prefix is deliberate: it reads as *no service verdict was reached — something in front of the API answered*, and it cannot collide with a wire `code` or a Router bucket, none of which are spelled that way.

**`ApiError.body_excerpt`** (keyword-only, defaults to `None`) keeps the text that response served. Whitespace-collapsed to one line, control characters stripped, capped at 256 characters. It is set only where the body was not the error envelope — where the response has already stated its cause, a second copy of the same text helps nobody — and `__str__` shows it only beside the synthetic `HTTP <status>` message, never spliced into a message the server actually sent.

**Retry behaviour is unchanged.** `RetryPolicy` keys on the status plus the two collectable buckets (`deadline_exceeded` on a `504`, `concurrency_limit_exceeded` on a `409`); `http_<status>` is neither, so such a 5xx remains "a completed 5xx that named no pace" and is not auto-retried. Asserted directly in `test_an_unrecognised_status_is_still_not_retried_on_its_own`.

**`http_<status>` survives the layer boundary unchanged.** `to_sdk_error` re-types a preserved Router bucket into its typed class; `http_503` is not one, so it arrives as a plain `ComfyError` still carrying `code="http_503"`. No code change was needed for this — it is pinned by a new test so a later widening of the re-typing table cannot silently swallow it.

## Judgment calls

- **Characters, not bytes.** The plan said "the first 256 bytes of `resp.text`"; the implementation caps at 256 *characters* of the whitespace-collapsed text, which is what the plan's own test criterion ("a 2 KB body is truncated to 256 chars") describes, and slicing raw bytes would have meant either splitting a multi-byte UTF-8 sequence or discarding the response's declared charset.
- **Control characters are stripped, and the C1 range with them.** Not in the plan. The excerpt is server-controlled text headed for a traceback and a log line, and the neighbouring `clean_request_id` bounds the request id for exactly that reason; an escape sequence in an error page must not repaint the terminal reading it.
- **One extra raise site in the same function.** `parse_or_raise` also raises `code="invalid_response"` for a *success* status whose body will not decode — a proxy interstitial served as a `200`. That has the identical defect (the message says the body would not decode; only the body says what answered), so it carries the excerpt too. It is one argument, purely additive, and `__str__` is unaffected there because that message is not the synthetic one.
- **`resp.text` is read behind a guard.** It raises `ResponseNotRead` on a streaming response nothing has read yet — the same case the existing `resp.json()` already degrades on — and a failure while composing an error message must not replace the error it was describing. Covered by `test_an_unread_streaming_body_degrades_instead_of_raising`.
- **Compatibility.** A caller matching `exc.code == "error"` to detect an unrecognised 5xx would need to match `exc.code.startswith("http_")` instead. Filed under Changed in the CHANGELOG rather than as a breaking change: `"error"` was the class default and was documented in the code as the meaningless one.
- **Negative-claim falsification does not apply.** The change adds no deny/dead-end path and no capability-denying string; it is purely additive information on an error that was already being raised.

## Verification

- `uv run --extra dev ruff check .` — all checks passed
- `uv run --extra dev ruff format --check .` — 51 files already formatted
- `uv run --extra dev mypy src` — no issues, 19 source files
- `uv run --extra dev pytest -q` — 739 passed, 4 skipped, 0 failed
- `python3 scripts/check_public_repo_hygiene.py` — no internal-only references found
- No existing test's expectation was modified; the tests diff is additions plus one import block. Nothing in the repo asserted `"error"` for a bare 5xx (`grep` over `tests/` for `== "error"` returns only `test_models_run_retry.py:1003`, which builds an `ApiError` by hand and therefore reads the untouched *class* default).

## Residual

- **`ApiError.body_excerpt` does not reach the `comfy_sdk` surface.** `translating()` converts every protocol `ApiError` into a `ComfyError` via `to_sdk_error`, and `ComfyError` has no `body_excerpt`, so an integrator catching `ComfyError` from `client.run()` / `client.models.run()` sees `code="http_503"` but not the text that names the cause — `str(exc)` there is still the bare `HTTP 503`. The code half of the fix crosses the boundary; the body half does not. This was left out deliberately: the plan named `comfy_low/errors.py`, `comfy_low/transport.py` and the code carry-through only, and `ComfyError`'s attribute surface is an explicitly-reviewed published contract (`_BASE_ATTRIBUTES` in `tests/test_error_contract.py`, spelled out precisely so that adding one is a deliberate edit). Completing it means: add `body_excerpt` to `ComfyError.__init__` and its class defaults, forward it in `to_sdk_error`, add it to `_BASE_ATTRIBUTES`, and decide whether `ComfyError.__str__` should mirror the `HTTP <status>` gating. The README bullet added here says explicitly that the text lives on the protocol-level exception, so the docs are not overclaiming in the meantime.
- **The router surface has the same defect and is untouched.** `comfy_sdk.router_exceptions.error_from_response` — a public, exported helper with no caller inside `src/` today — degrades a bare load-balancer `503` to `RouterError(detail="HTTP 503")` with `error_type=None` and the body dropped. `503` is deliberately absent from its `_ERROR_TYPE_BY_STATUS` (a gateway's `503` is not the router's `service_unavailable`), and that decision is correct and unchanged here; what is missing is the same body-excerpt keep-and-display on that path. The ticket scoped itself to the envelope fallback and says so.
- **Unexercised artifact: the router-sdk e2e harness.** The requirement that `http_<status>` be read as "no server verdict" is stated against a harness that lives in another repository, at a path this worker cannot read from its sandbox. I verified the SDK-side half of that contract instead — that `to_sdk_error` carries `http_503` through unchanged and that no re-typing or flattening happens on the way out — but I did not run, read, or otherwise confirm the harness's own `startswith("http_")` check, nor that its line reference is still current. If that check has moved or changed shape, this prefix may not be the one it is looking for.
- **Not reproduced against a live load balancer.** The `no healthy upstream` / `upstream connect error or disconnect/reset before headers` bodies come from the originating investigation, not from a capture I took. The tests drive real `httpx.Response` objects carrying those exact bodies through the real raise site, which exercises the code path end to end, but the wire shape itself (in particular the assumption that such a response carries no `X-Comfy-Error-Type`) is inherited rather than re-observed.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `ruff check .`: all checks passed; `ruff format --check .`: 51 files already formatted; `mypy src`: no issues in 19 source files; `pytest -q`: 739 passed, 4 skipped, 0 failed; `scripts/check_public_repo_hygiene.py`: clean
- **Deviations:** the excerpt is bounded in characters rather than bytes (see Judgment calls); `body_excerpt` is not propagated to the `comfy_sdk` exception surface (see Residual)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of proxy-generated and non-standard HTTP 5xx responses.
  - Error messages now preserve a sanitized, bounded excerpt of diagnostic response text.
  - Unknown HTTP failures now include status-specific codes such as `http_502`.
  - Invalid JSON and malformed error responses provide clearer context without exposing excessive or unsafe text.
  - Existing retry behavior and recognized error mappings remain unchanged.

- **Documentation**
  - Added guidance for interpreting fallback HTTP error codes and accessing response-body excerpts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->