### PR TITLE
feat(assets): add Asset.get_download_url and document Router image-to-image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ notes for each version.
 
 ### Added
 
+- `Asset.get_download_url()` / `AsyncAsset.get_download_url()` — a
+  directly-fetchable URL for an *uploaded* asset's bytes, mirroring
+  `Output.get_download_url()` (same `DownloadUrl`, commits the asset first if
+  needed). On Comfy Cloud / serverless it is a short-lived signed URL any
+  fetcher can read until `expires_at`, which is what lets a local image be
+  passed to a URL-taking image-to-image model via `client.models.run()`:
+  upload the file as an asset, resolve its URL, put the URL in the model's
+  input. The README's "Image to image — upload an asset first" section walks
+  through the flow.
 - Every exception `client.models.run()` raises **for a failed call** now
   carries the `Idempotency-Key` it was made under, on `.idempotency_key` — the
   typed `RouterError` buckets, a `RouterError` whose `error_type` this version

--- a/README.md
+++ b/README.md
@@ -474,21 +474,22 @@ print(result["output"]["results"][0]["url"])
 `Asset.get_download_url()` commits the asset if needed (hash → dedup probe →
 upload, exactly like submitting it in a workflow) and returns the same
 `DownloadUrl` as an output's `get_download_url()`: on Comfy Cloud / serverless
-a signed storage URL any fetcher can read until `expires_at` — which is what
-lets the provider behind Router pull your image without your API key. Mind the
-two caveats that follow from that: the URL is short-lived, so resolve it right
-before the run rather than storing it; and on a *self-hosted* backend the URL
-is the auth-guarded content endpoint, which an external provider cannot fetch
-— upload to Comfy Cloud (the default `COMFY_BASE_URL` surface) for Router
-inputs.
+a signed storage URL any fetcher can read until `expires_at` (`None` when the
+URL carries no expiry the SDK can read) — which is what lets the provider
+behind Router pull your image without your API key. Mind the two caveats that
+follow from that: the URL is short-lived, so resolve it right before the run
+rather than storing it; and on a *self-hosted* backend the URL is the
+auth-guarded content endpoint, which an external provider cannot fetch — upload
+to Comfy Cloud (the default `COMFY_BASE_URL` surface) for Router inputs.
 
 Some models take images inline instead of by URL — `bfl/flux-2-pro`'s
 `input_image` is base64, for example — and then there is nothing to upload:
 
 ```python
 import base64
+from pathlib import Path
 
-image_b64 = base64.b64encode(open("photo.png", "rb").read()).decode()
+image_b64 = base64.b64encode(Path("photo.png").read_bytes()).decode()
 result = client.models.run(
     "bfl/flux-2-pro",
     {"prompt": "make it watercolor", "input_image": image_b64},

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ produced it, or `None` for an asset with no producing job (e.g. a plain
 upload) — and `expires_at`, its retention deadline, or `None` if it doesn't
 expire.
 
+An uploaded asset can also hand out a directly-fetchable URL for its bytes —
+`asset.get_download_url()`, the same `DownloadUrl` an output returns (it
+commits first if needed). That is how a local image reaches a service that
+fetches by URL, e.g. an image-to-image model behind Comfy Router — see
+[Image to image — upload an asset first](#image-to-image--upload-an-asset-first).
+
 Delete an asset with `asset.delete()`, or by id alone with
 `client.assets.delete(asset_id)`:
 
@@ -437,6 +443,61 @@ async with AsyncComfy(api_key="comfyui-...") as client:
 
 There is no `run_async()`, and there will not be one — one operation, one name,
 and `await` is what makes it asynchronous.
+
+### Image to image — upload an asset first
+
+An image-to-image model takes an image *as input*, and Router forwards the
+model's native body unchanged — so the image goes in whatever form the
+provider documents. Most URL-taking models want a URL the provider can fetch,
+and your local file doesn't have one yet. Give it one by uploading it as an
+asset and handing the model the asset's download URL:
+
+```python
+client = Comfy(api_key="comfyui-...")
+
+# 1. Upload the local image (dedup-aware; a re-run re-uploads nothing) and
+#    resolve a short-lived, self-authorizing signed URL for it.
+asset = client.assets.from_file("photo.png")
+url = asset.get_download_url().url
+
+# 2. Pass that URL wherever the model's own input schema takes an image.
+result = client.models.run(
+    "wan/wan2.5-i2i-preview",
+    {
+        "input": {"images": [url], "prompt": "Make it golden."},
+        "parameters": {"size": "768*768"},
+    },
+)
+print(result["output"]["results"][0]["url"])
+```
+
+`Asset.get_download_url()` commits the asset if needed (hash → dedup probe →
+upload, exactly like submitting it in a workflow) and returns the same
+`DownloadUrl` as an output's `get_download_url()`: on Comfy Cloud / serverless
+a signed storage URL any fetcher can read until `expires_at` — which is what
+lets the provider behind Router pull your image without your API key. Mind the
+two caveats that follow from that: the URL is short-lived, so resolve it right
+before the run rather than storing it; and on a *self-hosted* backend the URL
+is the auth-guarded content endpoint, which an external provider cannot fetch
+— upload to Comfy Cloud (the default `COMFY_BASE_URL` surface) for Router
+inputs.
+
+Some models take images inline instead of by URL — `bfl/flux-2-pro`'s
+`input_image` is base64, for example — and then there is nothing to upload:
+
+```python
+import base64
+
+image_b64 = base64.b64encode(open("photo.png", "rb").read()).decode()
+result = client.models.run(
+    "bfl/flux-2-pro",
+    {"prompt": "make it watercolor", "input_image": image_b64},
+)
+```
+
+Which form a model takes is in its input schema — `GET
+/v2/models/{provider}/{model}/openapi.json`, or the model's page in the
+[Router model catalog](https://docs.comfy.org/development/comfy-router/models).
 
 Because the server may legitimately hold the connection for minutes, `run` uses
 its own 10-minute timeout rather than the client's (which is sized for ordinary

--- a/src/comfy_sdk/assets.py
+++ b/src/comfy_sdk/assets.py
@@ -27,6 +27,7 @@ from comfy_low.transport import AsyncComfyLow, ComfyLow
 
 from . import _core, _hashing
 from .exceptions import translating
+from .outputs import DownloadUrl
 
 Opener = Callable[[], "tuple[BinaryIO, int | None]"]
 Hasher = Callable[[], str]
@@ -159,6 +160,25 @@ class Asset(_AssetBase):
         assert self._id is not None
         return _core.asset_reference(self._id, hash=self._hash, file_path=self._file_path)
 
+    def get_download_url(self) -> DownloadUrl:
+        """A directly-fetchable URL for this asset's bytes (commits first if
+        needed).
+
+        The counterpart of ``Output.get_download_url`` for an *uploaded* asset:
+        hand the URL to anything that fetches by URL instead of streaming the
+        bytes through your process — e.g. a Comfy Router model whose input
+        takes an image URL. On a Cloud/serverless backend it is a short-lived,
+        self-authorizing signed URL readable until ``expires_at`` with no
+        further auth; on a self-hosted backend it is the content endpoint
+        itself (normal auth still applies, so an external service cannot fetch
+        it) and ``expires_at`` is ``None``.
+        """
+        self.commit()
+        assert self._id is not None
+        with translating():
+            url, expires_at = self._low.get_asset_content_url(self._id)
+        return DownloadUrl(url=url, expires_at=expires_at)
+
 
 class AsyncAsset(_AssetBase):
     """A lazy asset handle bound to the asynchronous client."""
@@ -203,6 +223,15 @@ class AsyncAsset(_AssetBase):
         await self.commit()
         assert self._id is not None
         return _core.asset_reference(self._id, hash=self._hash, file_path=self._file_path)
+
+    async def get_download_url(self) -> DownloadUrl:
+        """See the sync ``Asset.get_download_url`` for the redirect/inline
+        split."""
+        await self.commit()
+        assert self._id is not None
+        with translating():
+            url, expires_at = await self._low.get_asset_content_url(self._id)
+        return DownloadUrl(url=url, expires_at=expires_at)
 
 
 # ---- source builders (shared, sans-IO except explicit reads) ------------

--- a/src/comfy_sdk/assets.py
+++ b/src/comfy_sdk/assets.py
@@ -168,10 +168,18 @@ class Asset(_AssetBase):
         hand the URL to anything that fetches by URL instead of streaming the
         bytes through your process — e.g. a Comfy Router model whose input
         takes an image URL. On a Cloud/serverless backend it is a short-lived,
-        self-authorizing signed URL readable until ``expires_at`` with no
-        further auth; on a self-hosted backend it is the content endpoint
-        itself (normal auth still applies, so an external service cannot fetch
-        it) and ``expires_at`` is ``None``.
+        self-authorizing signed URL readable with no further auth; on a
+        self-hosted backend it is the content endpoint itself, where normal
+        auth still applies, so an external service cannot fetch it.
+
+        The returned ``expires_at`` is the signed URL's own expiry, read from
+        the URL when the SDK recognizes the signature format (today: GCS-style
+        ``X-Goog-Date``/``X-Goog-Expires`` query parameters). It is ``None``
+        whenever there is no expiry to read — always on a self-hosted backend,
+        and also for a signed URL in a format this SDK does not parse — so
+        treat ``None`` as "unknown", not "never expires". It is unrelated to
+        this handle's ``expires_at`` property, which is the asset's *retention*
+        deadline.
         """
         self.commit()
         assert self._id is not None

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from comfy_sdk import Comfy, HashMismatch, NotFound
+from comfy_sdk import AsyncComfy, Comfy, DownloadUrl, HashMismatch, NotFound
 
 
 def test_dedup_fast_path_skips_upload(server, tmp_path) -> None:
@@ -158,3 +158,52 @@ def test_delete_uncommitted_asset_raises(server) -> None:
             asset.delete()
 
     assert server.state.delete_count == 0
+
+
+# -- get_download_url: a fetchable URL for an *uploaded* asset ---------------
+
+_SIGNED_URL = (
+    "https://storage.googleapis.com/bucket/object"
+    "?X-Goog-Algorithm=GOOG4-RSA-SHA256"
+    "&X-Goog-Credential=example%2F20260710%2Fauto%2Fstorage%2Fgoog4_request"
+    "&X-Goog-Date=20260710T180000Z"
+    "&X-Goog-Expires=3600"
+    "&X-Goog-SignedHeaders=host"
+    "&X-Goog-Signature=deadbeef"
+)
+
+
+def test_get_download_url_commits_then_resolves_signed_url(server) -> None:
+    # Cloud path: the content endpoint redirects to a signed URL. Calling
+    # get_download_url on an uncommitted handle must upload first, then
+    # resolve — the flow that feeds an uploaded image to a URL-taking model.
+    server.state.redirect_content_to = _SIGNED_URL
+    with Comfy() as client:
+        asset = client.assets.from_bytes(b"router-input-bytes", filename="photo.png")
+        download = asset.get_download_url()
+
+    assert isinstance(download, DownloadUrl)
+    assert asset.id == "asset_uploaded_01"  # committed as a side effect
+    assert server.state.upload_count == 1
+    assert download.url == _SIGNED_URL
+    assert download.expires_at == datetime(2026, 7, 10, 19, 0, tzinfo=timezone.utc)
+
+
+def test_get_download_url_self_hosted_returns_content_endpoint(server) -> None:
+    with Comfy() as client:
+        asset = client.assets.from_bytes(b"router-input-bytes", filename="photo.png")
+        download = asset.get_download_url()
+
+    assert download.url == f"{server.base_url}/api/v2/assets/{asset.id}/content"
+    assert download.expires_at is None
+
+
+async def test_async_get_download_url_commits_then_resolves(server) -> None:
+    server.state.redirect_content_to = _SIGNED_URL
+    async with AsyncComfy() as client:
+        asset = client.assets.from_bytes(b"router-input-bytes", filename="photo.png")
+        download = await asset.get_download_url()
+
+    assert asset.id == "asset_uploaded_01"
+    assert download.url == _SIGNED_URL
+    assert download.expires_at == datetime(2026, 7, 10, 19, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## What

An image-to-image call through Comfy Router needs the input image in the form the model's native schema takes. For URL-taking models (e.g. `wan/wan2.5-i2i-preview`'s `input.images`) that means a URL the provider can fetch, which a local file doesn't have. Uploaded assets already resolve one server-side (the same `GET /api/v2/assets/{id}/content` endpoint outputs use), but the public `Asset` handle never exposed it — `Output.get_download_url()` existed, `Asset` had nothing.

- **`Asset.get_download_url()` / `AsyncAsset.get_download_url()`**: commits the asset if needed (hash → dedup probe → upload), then resolves the same `DownloadUrl` an `Output` returns — a short-lived, self-authorizing signed URL on Cloud/serverless, or the auth-guarded content endpoint (with `expires_at=None`) on self-hosted.
- **README**: new "Image to image — upload an asset first" section showing upload → `get_download_url()` → `models.run` with a URL-taking model, the base64-inline alternative for models like `bfl/flux-2-pro`, and a pointer from the assets section.
- **Tests**: commit-on-demand behavior plus both URL shapes (Cloud redirect with parsed expiry, self-hosted inline with no expiry), sync and async.
- **CHANGELOG**: entry under Unreleased.

## Why

There was no documented (or possible, without reaching into `comfy_low`) way to feed a local image to a Router image-to-image model. A matching docs.comfy.org page and a mirror change in the TypeScript SDK (`Asset.getDownloadUrl()`) are in flight; the docs page's Python snippet depends on the release that carries this.

## Validation

Full local CI suite green: `ruff check`, `ruff format --check`, `mypy src`, `pytest` (721 passed, 4 skipped), and `check_public_repo_hygiene.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLwhWvHT34Df3199cAAooJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLwhWvHT34Df3199cAAooJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous methods for retrieving download URLs for uploaded assets.
  * Download URLs include expiration details and support signed URLs.
  * Assets are automatically committed before a URL is generated when needed.
  * Added support for asset-based image-to-image workflows, including URL and inline image inputs.

* **Documentation**
  * Added examples covering asset downloads, URL lifetimes, self-hosted usage, and model input schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->