### PR TITLE
ci: fail the PR check while a do-not-merge label is present

### DIFF
--- a/.github/workflows/ci-block-do-not-merge.yml
+++ b/.github/workflows/ci-block-do-not-merge.yml
@@ -1,0 +1,37 @@
+name: CI - Block do-not-merge
+
+# Fails the PR check whenever a `do-not-merge` label is present: the PR is
+# waiting on something outside this repo (typically a Comfy Cloud deployment
+# of the routes it talks to) and would be broken if released now.
+#
+# Posts on every PR event that can change the outcome, so the check exists on
+# every PR and can be marked as a required status check in branch protection
+# to become a hard block. Until then it is a red flag a reviewer sees.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  block-do-not-merge:
+    name: Block do-not-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if do-not-merge label is present
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$PR_LABELS" | jq -e 'index("do-not-merge")' > /dev/null; then
+            echo "::error::PR has the \`do-not-merge\` label. Remove the label before merging."
+            {
+              echo "## ❌ Blocked by \`do-not-merge\` label"
+              echo
+              echo "Remove the \`do-not-merge\` label to unblock this check."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "No \`do-not-merge\` label — OK."


### PR DESCRIPTION
## ELI-5

Some PRs are finished but must not land yet, because the server side they talk to is not deployed. Putting a `do-not-merge` label on such a PR now turns one CI check red, so nobody merges it by accident. Take the label off and the check goes green.

## What

- New workflow `CI - Block do-not-merge`: fails whenever the PR carries the `do-not-merge` label, passes otherwise. Runs on open, reopen, push, label and unlabel, so the check exists on every PR.
- Same shape as the check the cloud repo uses, with the added triggers so it posts on every PR rather than only on label changes.

## Why now

The queue (`submit` / `subscribe` / `handle`) SDK PR is complete but the `/requests` routes it calls are only on a Comfy Cloud feature branch, so releasing it today would break callers. The label is on that PR already; this makes it visible in CI.

## Making it a hard block

Mark `Block do-not-merge` as a required status check in branch protection. Until then the red check is advisory.

## Testing

Workflow is a single `jq` test on the event payload, mirrored from the cloud repo where it has run for months. It can be exercised on this PR by adding and removing the label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks for pull requests marked **do-not-merge**.
  * These checks now fail and display an explanatory summary when the label is present, helping prevent unintended merges.
  * Pull requests without the label continue to pass this validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->