### PR TITLE
docs(changelog): cut 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ notes for each version.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-10
+
 ### Added
 
 - `Asset.get_download_url()` / `AsyncAsset.get_download_url()` — a
@@ -398,6 +400,7 @@ First public release of the Comfy API v2 Python SDK (`comfy-sdk`).
 - Sync and async clients. Python 3.10+.
 
 [unreleased]: https://github.com/Comfy-Org/comfy-python-sdk/compare/v0.1.9...HEAD
+[0.2.0]: https://github.com/Comfy-Org/comfy-python-sdk/compare/v0.1.9...v0.2.0
 [0.1.9]: https://github.com/Comfy-Org/comfy-python-sdk/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Comfy-Org/comfy-python-sdk/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Comfy-Org/comfy-python-sdk/compare/v0.1.5...v0.1.7


### PR DESCRIPTION
## ELI-5

This moves everything under `## [Unreleased]` in the changelog under a `## [0.2.0] - 2026-09-10` heading, so the next GitHub Release (tag `v0.2.0`) has a matching changelog section. Nothing else changes: the version is injected from the tag at publish time, so `pyproject.toml` stays a placeholder per CONTRIBUTING.md.

#141 has merged, so this is the one-commit cut on top of `main`.

## What ships in 0.2.0

- `Asset.get_download_url()` / `AsyncAsset.get_download_url()` (#142)
- `ApiError.body_excerpt`, shown by `str()` at both layers (#141)
- Unrecognised error code `http_<status>` instead of `"error"` (#141)

## Why 0.2.0 rather than 0.1.10

The `.code` string for an unrecognised error changes, and it keeps the two SDKs in lockstep with the TypeScript 0.2.0 cut. Edit the heading in this PR if 0.1.10 is preferred.

## Draft release notes for `v0.2.0`

<details><summary>Release notes (paste into the GitHub Release)</summary>

Uploaded assets get a directly-fetchable URL, and an error answered by something in front of the service now says so — and keeps the one line that explains it.

## Highlights

**`Asset.get_download_url()` / `AsyncAsset.get_download_url()`.** A directly-fetchable URL for an uploaded asset's bytes, mirroring `Output.get_download_url()` (same `DownloadUrl`, commits the asset first if needed). On Comfy Cloud it is a short-lived signed URL any fetcher can read until `expires_at`, which is what lets a local image be passed to a URL-taking image-to-image model via `client.models.run()`: upload the file as an asset, resolve its URL, put the URL in the model's input. The README's "Image to image — upload an asset first" section walks through the flow.

**An error nothing in the stack recognised names its status.** Such a response now carries `.code == "http_<status>"` (`http_503`, `http_500`) instead of `"error"`. It is reached only after the envelope's own `code`, Router's error bucket and the status table have all declined, so a bare `401` still maps to `Unauthorized` and every documented code is untouched. Read it as *answered by something in front of Router rather than by the service itself, so no service verdict was reached; retry per your own policy* — nothing about what the SDK retries changed.

**The body that explains a bare `503` is kept.** A load balancer's `no healthy upstream` or `upstream connect error or disconnect/reset before headers` arrives as plain text with no JSON and no request id, and used to be discarded with the response. It is now on `comfy_low.errors.ApiError.body_excerpt`, and `str()` of the exception you catch — at both the protocol and the SDK layer — reads `HTTP 503: no healthy upstream`. The excerpt is one line, capped at 256 characters, with control, bidi and zero-width characters replaced, and it is `None` whenever the response stated a message of its own.

## Upgrading

Additive except for one string: code that matched the literal `"error"` on an unrecognised `ComfyError` should match `code.startswith("http_")` instead.

Full detail in [CHANGELOG.md](https://github.com/Comfy-Org/comfy-python-sdk/blob/main/CHANGELOG.md).

</details>

## Not in this release

- #137 (queue submit/subscribe/handle) carries `do-not-merge` until the router queue routes are deployed to cloud.
